### PR TITLE
Fix recent projects clickable in Tauri desktop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes (2026-02-18)
 
 ### Fixed
+- **Recent projects clickable in Tauri desktop mode** - Recent workspaces were greyed out with "Re-select folder to reopen" even on desktop where direct filesystem access is available
+  - In Tauri mode, recent projects in both the WorkspaceSelector and ProjectManager dropdown now open directly by path (no dialog needed)
+  - Browser security note only shown in browser mode where it actually applies
+  - Added `handleOpenRecentProject` handler in App.tsx that opens a workspace directly by stored path
+  - Files modified: `WorkspaceSelector.tsx`, `ProjectManager.tsx`, `App.tsx`
+
 - **Workspace switching not working** - Selecting a different workspace or creating a new project while inside a project would not actually switch to it
   - Root cause: `handleWorkspaceSelected` in App.tsx created a local `rootPath` variable but never called `setRootPath()` to update the Zustand store
   - Added `setRootPath(newRootPath)` call and close all stale tabs from the previous workspace on switch

--- a/src/components/workspace/ProjectManager.tsx
+++ b/src/components/workspace/ProjectManager.tsx
@@ -26,6 +26,7 @@ import {
   Pencil,
   Clock,
 } from 'lucide-react';
+import { isTauriEnvironment } from '@/modules/workspace/BackendFactory';
 
 interface RecentWorkspace {
   path: string;
@@ -36,6 +37,7 @@ interface RecentWorkspace {
 interface ProjectManagerProps {
   currentProjectName: string;
   onSwitchProject: () => void;
+  onOpenRecentProject?: (path: string) => void;
   onRenameProject?: (newName: string) => Promise<void>;
   recentProjects?: RecentWorkspace[];
 }
@@ -43,9 +45,11 @@ interface ProjectManagerProps {
 export function ProjectManager({
   currentProjectName,
   onSwitchProject,
+  onOpenRecentProject,
   onRenameProject,
   recentProjects = [],
 }: ProjectManagerProps) {
+  const isTauri = isTauriEnvironment();
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [newName, setNewName] = useState(currentProjectName);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -111,7 +115,8 @@ export function ProjectManager({
                 <DropdownMenuItem
                   key={project.path}
                   className="flex items-center justify-between"
-                  disabled // Due to browser security, recent workspaces need re-selection
+                  disabled={!isTauri}
+                  onClick={() => isTauri && onOpenRecentProject?.(project.path)}
                 >
                   <span className="truncate">{project.name}</span>
                   <span className="text-xs text-muted-foreground ml-2">
@@ -119,9 +124,11 @@ export function ProjectManager({
                   </span>
                 </DropdownMenuItem>
               ))}
-              <p className="px-2 py-1 text-xs text-muted-foreground">
-                Re-select folder to reopen
-              </p>
+              {!isTauri && (
+                <p className="px-2 py-1 text-xs text-muted-foreground">
+                  Re-select folder to reopen
+                </p>
+              )}
             </>
           )}
         </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- **Recent projects now clickable in Tauri mode**: In desktop mode, recent workspaces in both the initial WorkspaceSelector dialog and the in-app ProjectManager dropdown can now be opened directly by clicking them (no directory picker dialog needed)
- **Browser security note hidden in Tauri**: The "Recent workspaces require re-selecting the folder due to browser security" note only shows in browser mode where it actually applies
- Added `handleOpenRecentProject` in App.tsx that creates a backend and workspace service directly from the stored path

## Test plan
- [ ] In Tauri desktop mode: open a project, then use project dropdown → click a recent project → should switch immediately
- [ ] In Tauri desktop mode: close to workspace selector → click a recent workspace → should open directly
- [ ] In browser mode: recent projects should still show as disabled with browser security note

🤖 Generated with [Claude Code](https://claude.com/claude-code)