### PR TITLE
feat(stream-d): iCloud Drive + mobile access docs (v2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Mobile access docs (Stream D1, v2.0).** Five new public docs pages plus
+  an in-app `Settings → Mobile` page document the cloud-sync workaround so
+  users can read their workspace on iPhone or Android today, before the
+  dedicated mobile reader (D2) ships.
+  - **Hub page** at `/docs/mobile-access/` with a four-card provider grid
+    and a "which one should I pick" decision matrix.
+  - **Per-provider setup guides** at `/docs/mobile-access/icloud`,
+    `/docs/mobile-access/dropbox`, `/docs/mobile-access/syncthing`, and
+    `/docs/mobile-access/google-drive`. Each is a step-by-step guide with
+    placeholder screenshot slots and a "things to know" callout for sync
+    caveats.
+  - **In-app `Settings → Mobile` page** (`MobileSettingsPage.tsx`) mirrors
+    the web content using shadcn Tabs, with documented iOS deep links
+    (`shareddocuments://` for iCloud Files, `dbapi-2://1/connect` for
+    Dropbox) and a "Full guide" link out to the matching website page for
+    each tab.
+  - **README + FAQ updates.** README gains a "Mobile access" section. FAQ
+    gains a new "Can I use Projelli on my phone?" item, and the existing
+    "Will there be a mobile app?" item now points users at the cloud sync
+    workaround and the in-beta dedicated reader.
+  - **Homepage docs nav** gains a "Mobile access" link in the footer.
+  - **Lint coverage.** All five new HTML pages are added to the
+    `website-content-lint` allowlist (no em dashes, no banned marketing
+    words, canonical link present).
+  - Files added:
+    `website/docs/mobile-access/{index,icloud,dropbox,syncthing,google-drive}.html`,
+    `website/docs/mobile-access/screenshots/README.md`,
+    `src/components/settings/MobileSettingsPage.tsx`,
+    `tests/unit/components/settings/MobileSettingsPage.test.tsx`.
+  - Files modified: `README.md`, `website/index.html`,
+    `website/docs/faq.html`, `src/components/settings/MobileSettings.tsx`
+    (now re-exports `MobileSettingsPage`),
+    `tests/unit/website-content-lint.test.ts`.
+
 - **Templates Marketplace (Stream C1, v2.0).** New "Marketplace" surface
   under Settings lets users browse, install, update, and uninstall workflow
   templates published in `projelli/community-templates`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The pitch in one sentence: it's Obsidian for the AI era, built for founders, sol
 
 **Linux:** AppImage / `.deb` / `.rpm` builds are produced but Linux is not officially supported in v1.6. Coming as v1.7 after the launch settles.
 
+## Mobile access
+
+Projelli is a desktop app, but your workspace is just a folder of plain Markdown files. Point that folder at iCloud Drive, Dropbox, Syncthing, or Google Drive on your computer and your notes show up on your iPhone or Android in the matching files app, with no new account and no extra cost. The full setup steps (one guide per provider, plus a "which one should I pick" decision matrix) live at [projelli.com/docs/mobile-access/](https://projelli.com/docs/mobile-access/). A dedicated Projelli mobile reader is in beta and will land in the v2.0 cycle.
+
 ## Development
 
 ```bash

--- a/src/components/settings/MobileSettings.tsx
+++ b/src/components/settings/MobileSettings.tsx
@@ -1,19 +1,7 @@
 /**
- * MobileSettings — placeholder page.
- *
- * Stream D will populate this with iOS and cross-device access controls.
- * For now it's a shell so the nav item resolves.
+ * MobileSettings — kept as a thin re-export so existing imports
+ * (SettingsModal, placeholder tests) continue to work after Stream D1
+ * shipped the real implementation in `MobileSettingsPage`.
  */
 
-export function MobileSettings() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-semibold tracking-tight">Mobile</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Access your workspace from iOS and other devices. Stream D will populate this page.
-        </p>
-      </div>
-    </div>
-  );
-}
+export { MobileSettingsPage as MobileSettings } from '@/components/settings/MobileSettingsPage';

--- a/src/components/settings/MobileSettingsPage.tsx
+++ b/src/components/settings/MobileSettingsPage.tsx
@@ -1,0 +1,212 @@
+/**
+ * MobileSettingsPage — Settings → Mobile.
+ *
+ * Mirrors the public web docs at /docs/mobile-access/ in a more compact form
+ * suitable for the Settings modal. Four tabs (iCloud / Dropbox / Syncthing /
+ * Google Drive), each rendering a short steps list, key tips, and a deep-link
+ * "open" button when a stable iOS scheme is known.
+ *
+ * Stream D1 of the v2.0 mega-release. The dedicated mobile reader (D2) is
+ * still in beta; this page documents the cloud-sync workaround that ships
+ * the v2.0 mobile story today.
+ */
+
+import { useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { ExternalLink } from 'lucide-react';
+
+type ProviderId = 'icloud' | 'dropbox' | 'syncthing' | 'gdrive';
+
+interface ProviderTab {
+  id: ProviderId;
+  label: string;
+  /** One-line tagline shown above the steps. */
+  tagline: string;
+  /** Numbered setup steps. Kept short; the website has the long form. */
+  steps: string[];
+  /** Bullet caveats / "things to know" list. */
+  tips: string[];
+  /** Deep link to the provider's iOS / native app, when stable. */
+  deepLink?: { href: string; label: string };
+  /** Web docs URL for the matching long-form guide. */
+  docsHref: string;
+}
+
+const PROVIDERS: ProviderTab[] = [
+  {
+    id: 'icloud',
+    label: 'iCloud Drive',
+    tagline: 'Easiest path on Apple devices. About 5 minutes.',
+    steps: [
+      'On your Mac, make sure iCloud Drive is on under System Settings → Apple ID → iCloud.',
+      'In Projelli, open File → Open Workspace and pick a folder inside ~/Library/Mobile Documents/com~apple~CloudDocs/. A folder called "Projelli" works well.',
+      'Wait for the first sync to finish (watch the cloud icons in Finder).',
+      'On your iPhone, open the Files app → Browse → iCloud Drive → Projelli to read your workspace.',
+    ],
+    tips: [
+      'Treat your phone as read-only for now to avoid conflict copies.',
+      'Free iCloud tier is 5 GB. A typical Projelli workspace fits easily.',
+      'For pretty Markdown rendering on iPhone, install a Markdown reader like Taio or 1Writer and point it at the same iCloud folder.',
+    ],
+    // Apple's documented Files app deep link. Opens straight into Files.
+    deepLink: { href: 'shareddocuments://', label: 'Open Files on iPhone' },
+    docsHref: 'https://projelli.com/docs/mobile-access/icloud',
+  },
+  {
+    id: 'dropbox',
+    label: 'Dropbox',
+    tagline: 'Cross-platform. Reliable conflict handling. Works on iOS and Android.',
+    steps: [
+      'Install Dropbox for desktop from dropbox.com/install if you don\'t already have it.',
+      'In Projelli, open File → Open Workspace and pick a folder inside your Dropbox folder.',
+      'Wait for the green checkmark next to the folder in Finder / File Explorer.',
+      'Install the Dropbox iOS or Android app, sign in, and navigate to the Projelli folder. Tap any .md file.',
+    ],
+    tips: [
+      'Dropbox creates clearly labeled "conflicted copy" files when both devices edit at once. Still cleanest to edit on one at a time.',
+      'Free tier is 2 GB. Markdown is tiny so this is rarely the bottleneck.',
+      'If you use Smart Sync, right-click your Projelli folder and "Make Available Offline" so Projelli can always read from disk.',
+    ],
+    // Documented Dropbox iOS scheme used to open the app.
+    deepLink: { href: 'dbapi-2://1/connect', label: 'Open Dropbox on iPhone' },
+    docsHref: 'https://projelli.com/docs/mobile-access/dropbox',
+  },
+  {
+    id: 'syncthing',
+    label: 'Syncthing',
+    tagline: 'Open source, peer-to-peer. Your data stays on your devices.',
+    steps: [
+      'Install Syncthing on your computer from syncthing.net/downloads. The admin UI opens at http://127.0.0.1:8384.',
+      'In Syncthing, add a folder (label "Projelli") pointing at a local path like ~/Projelli-Sync/.',
+      'In Projelli, open File → Open Workspace and select that same folder.',
+      'On Android: install Syncthing-Fork and pair using your computer\'s device ID. On iPhone: use Möbius Sync (paid) and follow the same pairing flow.',
+    ],
+    tips: [
+      'Both devices must be running Syncthing for files to sync. Sleeping your laptop pauses sync.',
+      'iOS does not have an official free Syncthing client. If you don\'t want to pay for Möbius Sync, the iCloud Drive tab is a better fit on iPhone.',
+      'For nicer Markdown rendering on Android, install Markor and open .md files with that.',
+    ],
+    docsHref: 'https://projelli.com/docs/mobile-access/syncthing',
+  },
+  {
+    id: 'gdrive',
+    label: 'Google Drive',
+    tagline: 'Best on Android. Requires the Google Drive desktop app in "Mirror" mode.',
+    steps: [
+      'Install Google Drive for desktop from google.com/drive/download. When asked, choose "Mirror files" (not "Stream files"), so a real local copy lives on your hard drive.',
+      'In Projelli, open File → Open Workspace and pick a folder inside the mirrored Drive location.',
+      'Wait for the green checkmark in Finder / File Explorer.',
+      'On Android, open the Google Drive app and navigate to the Projelli folder. On iPhone, install Google Drive for iOS and do the same.',
+    ],
+    tips: [
+      '"Mirror" mode is required. "Stream" mode keeps files cloud-only and Projelli won\'t reliably read them.',
+      'Free tier is 15 GB shared across Drive, Gmail, and Photos. Check your overall Google storage isn\'t already full.',
+      'On Android, tap a .md file to pick a default Markdown app once. Markor is a solid free choice.',
+    ],
+    docsHref: 'https://projelli.com/docs/mobile-access/google-drive',
+  },
+];
+
+export function MobileSettingsPage() {
+  const [active, setActive] = useState<ProviderId>('icloud');
+
+  return (
+    <div className="space-y-6" data-testid="mobile-settings-page">
+      <header>
+        <h2 className="text-2xl font-semibold tracking-tight">Mobile</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Read your Projelli workspace on your phone today. Point Projelli at a synced
+          folder on your computer (iCloud, Dropbox, Syncthing, or Google Drive) and the
+          same files show up on your phone in the matching app. The dedicated Projelli
+          mobile reader is in beta and lands in the v2.0 cycle.
+        </p>
+      </header>
+
+      <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm">
+        <strong className="text-foreground">Heads up:</strong>{' '}
+        Treat your phone as read-only while using the cloud sync workaround. Editing the
+        same file on two devices in quick succession can produce a conflict copy.
+      </div>
+
+      <Tabs
+        value={active}
+        onValueChange={(v) => {
+          setActive(v as ProviderId);
+        }}
+      >
+        <TabsList className="grid w-full grid-cols-4">
+          {PROVIDERS.map((p) => (
+            <TabsTrigger
+              key={p.id}
+              value={p.id}
+              data-testid={`mobile-tab-${p.id}`}
+            >
+              {p.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {PROVIDERS.map((p) => (
+          <TabsContent
+            key={p.id}
+            value={p.id}
+            data-testid={`mobile-panel-${p.id}`}
+            className="space-y-5 pt-4"
+          >
+            <p className="text-sm text-muted-foreground">{p.tagline}</p>
+
+            <section>
+              <h3 className="text-sm font-semibold mb-2">Setup steps</h3>
+              <ol className="list-decimal list-inside space-y-2 text-sm text-foreground/90">
+                {p.steps.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </section>
+
+            <section>
+              <h3 className="text-sm font-semibold mb-2">Things to know</h3>
+              <ul className="list-disc list-inside space-y-1.5 text-sm text-muted-foreground">
+                {p.tips.map((tip, i) => (
+                  <li key={i}>{tip}</li>
+                ))}
+              </ul>
+            </section>
+
+            <div className="flex flex-wrap gap-2 pt-1">
+              {p.deepLink && (
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 text-xs"
+                  data-testid={`mobile-deeplink-${p.id}`}
+                >
+                  <a href={p.deepLink.href}>
+                    {p.deepLink.label}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </Button>
+              )}
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="gap-1.5 text-xs"
+                data-testid={`mobile-docs-${p.id}`}
+              >
+                <a href={p.docsHref} target="_blank" rel="noopener noreferrer">
+                  Full guide
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </Button>
+            </div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+export default MobileSettingsPage;

--- a/tests/unit/components/settings/MobileSettingsPage.test.tsx
+++ b/tests/unit/components/settings/MobileSettingsPage.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * MobileSettingsPage (Stream D1).
+ *
+ * The page renders four provider tabs (iCloud / Dropbox / Syncthing / Google
+ * Drive) using shadcn Tabs. Each tab shows a steps list, tips, a "Full guide"
+ * link to the matching website docs page, and (where stable) a deep link
+ * button to open the provider's iOS app.
+ *
+ * What this guards:
+ *   - All four tab triggers render with stable testids.
+ *   - Default tab (iCloud) shows its content and the documented Files deep link.
+ *   - Switching tabs swaps the visible panel.
+ *   - The "Full guide" link points at /docs/mobile-access/<provider> on projelli.com.
+ *   - The Dropbox tab exposes the documented dbapi-2 deep link.
+ *   - Syncthing has no deep link (intentional — no stable iOS scheme).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MobileSettingsPage } from '@/components/settings/MobileSettingsPage';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MobileSettingsPage', () => {
+  it('renders the page heading and all four provider tab triggers', () => {
+    render(<MobileSettingsPage />);
+    expect(screen.getByRole('heading', { name: /mobile/i })).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-icloud')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-dropbox')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-syncthing')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-gdrive')).toBeInTheDocument();
+  });
+
+  it('opens on the iCloud tab by default and exposes the Files deep link', () => {
+    render(<MobileSettingsPage />);
+    expect(screen.getByTestId('mobile-panel-icloud')).toBeInTheDocument();
+    const deepLink = screen.getByTestId('mobile-deeplink-icloud');
+    expect(deepLink).toHaveAttribute('href', 'shareddocuments://');
+    const fullGuide = screen.getByTestId('mobile-docs-icloud');
+    expect(fullGuide).toHaveAttribute(
+      'href',
+      'https://projelli.com/docs/mobile-access/icloud',
+    );
+  });
+
+  it('switches to the Dropbox tab and shows its dbapi-2 deep link', () => {
+    render(<MobileSettingsPage />);
+    fireEvent.click(screen.getByTestId('mobile-tab-dropbox'));
+    expect(screen.getByTestId('mobile-panel-dropbox')).toBeInTheDocument();
+    const deepLink = screen.getByTestId('mobile-deeplink-dropbox');
+    expect(deepLink).toHaveAttribute('href', 'dbapi-2://1/connect');
+    expect(screen.getByTestId('mobile-docs-dropbox')).toHaveAttribute(
+      'href',
+      'https://projelli.com/docs/mobile-access/dropbox',
+    );
+  });
+
+  it('switches to Google Drive and shows its full-guide link', () => {
+    render(<MobileSettingsPage />);
+    fireEvent.click(screen.getByTestId('mobile-tab-gdrive'));
+    expect(screen.getByTestId('mobile-panel-gdrive')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-docs-gdrive')).toHaveAttribute(
+      'href',
+      'https://projelli.com/docs/mobile-access/google-drive',
+    );
+  });
+
+  it('does not render a deep link for Syncthing (no stable iOS scheme)', () => {
+    render(<MobileSettingsPage />);
+    fireEvent.click(screen.getByTestId('mobile-tab-syncthing'));
+    expect(screen.getByTestId('mobile-panel-syncthing')).toBeInTheDocument();
+    expect(screen.queryByTestId('mobile-deeplink-syncthing')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mobile-docs-syncthing')).toHaveAttribute(
+      'href',
+      'https://projelli.com/docs/mobile-access/syncthing',
+    );
+  });
+});

--- a/tests/unit/website-content-lint.test.ts
+++ b/tests/unit/website-content-lint.test.ts
@@ -33,6 +33,12 @@ const TARGETS = [
   'legal/privacy.html',
   'legal/terms.html',
   'legal/eula.html',
+  // Stream D1 (v2.0) — mobile access docs.
+  'docs/mobile-access/index.html',
+  'docs/mobile-access/icloud.html',
+  'docs/mobile-access/dropbox.html',
+  'docs/mobile-access/syncthing.html',
+  'docs/mobile-access/google-drive.html',
 ];
 
 const BANNED_WORDS = [

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -166,6 +166,11 @@
     </details>
 
     <details>
+      <summary>Can I use Projelli on my phone?</summary>
+      <p>Yes, today, as a reader. Point your Projelli workspace at a folder inside iCloud Drive, Dropbox, Syncthing, or Google Drive on your computer, then open the same folder in your phone's Files / Dropbox / Drive app. Your notes show up on the phone in seconds. See the <a href="/docs/mobile-access/">Mobile access guide</a> for the four step-by-step setups, including which one to pick based on what you already use.</p>
+    </details>
+
+    <details>
       <summary>Is the source code open?</summary>
       <p>The full source code is visible at <a href="https://github.com/projelli/projelli">github.com/projelli/projelli</a>, but Projelli is closed-source proprietary software, you cannot redistribute, fork, or build a competing product from it. The source is visible so you can verify what the app does (privacy, security, etc.) but not so you can ship it yourself.</p>
     </details>
@@ -176,8 +181,8 @@
     </details>
 
     <details>
-      <summary>Will there be a mobile app?</summary>
-      <p>Not in v1. Projelli is a desktop product. A mobile app would need to solve sync (since mobile and desktop need to share the same workspace), which contradicts the local-first design. If we ever do mobile, it'll be a separate product, not the same one.</p>
+      <summary>Will there be a Projelli mobile app?</summary>
+      <p>A dedicated Projelli mobile reader is in beta and will land in the v2.0 cycle. It'll focus on read access first (browsing, searching, and tapping through wiki-links on the phone), with editing as a follow-up once we've gotten read right. Until that ships, the supported way to access your workspace on a phone is the cloud sync workaround documented in the <a href="/docs/mobile-access/">Mobile access guide</a>: point Projelli at a folder inside iCloud Drive, Dropbox, Syncthing, or Google Drive, then open the same folder on your phone in the matching app. It works today on every iPhone and Android with no extra install.</p>
     </details>
 
     <details>

--- a/website/docs/mobile-access/dropbox.html
+++ b/website/docs/mobile-access/dropbox.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropbox setup, Projelli</title>
+  <meta name="description" content="Step-by-step: read your Projelli workspace on iPhone or Android using Dropbox. Works cross-platform.">
+  <link rel="canonical" href="https://projelli.com/docs/mobile-access/dropbox">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .step { background: #F8FAFC; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; }
+    .step h3 { margin-top: 0; color: #3B82F6; }
+    .warning { background: #FEF3C7; border-left: 3px solid #F59E0B; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .warning strong { color: #111F35; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+    figure { margin: 24px 0; }
+    figure .placeholder { display: flex; align-items: center; justify-content: center; min-height: 240px; background: #F1F5F9; border: 2px dashed #CBD5E1; border-radius: 8px; color: #94A3B8; font-size: 0.875rem; padding: 24px; text-align: center; }
+    figcaption { color: #94A3B8; font-size: 0.8125rem; margin-top: 8px; text-align: center; font-style: italic; }
+    .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
+    .next-link:hover { text-decoration: none; opacity: 0.9; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+
+<body>
+  <div class="container">
+    <a href="/docs/mobile-access/" class="back">← Back to Mobile access</a>
+    <h1>Dropbox setup</h1>
+    <p class="meta">Cross-platform. Works on iOS, Android, and the web.</p>
+
+    <p>Dropbox is the most reliable cross-platform path. If you already pay for Dropbox or have it installed, this is the shortest setup of any non-Apple option. The same workflow also covers OneDrive (and any other sync service that gives you a regular folder on disk).</p>
+
+    <h2>Step 1: Install Dropbox on your computer</h2>
+
+    <div class="step">
+      <ol>
+        <li>If you don't already have Dropbox installed, grab the desktop app from <a href="https://www.dropbox.com/install" target="_blank" rel="noopener">dropbox.com/install</a>.</li>
+        <li>Sign in. The installer creates a <strong>Dropbox</strong> folder on your computer (usually <code>~/Dropbox</code> on Mac and Linux, or <code>C:\Users\YourName\Dropbox</code> on Windows).</li>
+        <li>Open the Dropbox folder once to confirm it's syncing. You should see the green checkmark icon next to fully-synced files.</li>
+      </ol>
+    </div>
+
+    <h2>Step 2: Point Projelli at Dropbox</h2>
+
+    <div class="step">
+      <ol>
+        <li>In Projelli, open <strong>File → Open Workspace</strong>.</li>
+        <li>Navigate to your Dropbox folder.</li>
+        <li>Create a new folder called <strong>Projelli</strong> inside Dropbox (or pick an existing one).</li>
+        <li>Select the folder and click <strong>Open</strong>.</li>
+      </ol>
+      <p>Every Markdown file Projelli writes from now on lives in Dropbox and syncs automatically.</p>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Projelli with workspace pointing at Dropbox folder]</div>
+      <figcaption>TODO: real screenshot of Projelli's workspace selector pointing at the Dropbox folder.</figcaption>
+    </figure>
+
+    <h2>Step 3: Wait for sync</h2>
+
+    <p>Open the Dropbox folder in Finder or File Explorer and watch for the green checkmark next to your Projelli folder. Markdown files are tiny, so this usually finishes in seconds.</p>
+
+    <h2>Step 4: Open your workspace on your phone</h2>
+
+    <div class="step">
+      <h3>iPhone</h3>
+      <ol>
+        <li>Install <a href="https://apps.apple.com/us/app/dropbox/id327630330" target="_blank" rel="noopener">Dropbox for iOS</a> from the App Store.</li>
+        <li>Sign in with the same account you use on your computer.</li>
+        <li>Tap <strong>Files</strong> at the bottom, then navigate to your <strong>Projelli</strong> folder.</li>
+        <li>Tap any <code>.md</code> file to read it. Dropbox renders Markdown nicely on iOS.</li>
+      </ol>
+    </div>
+
+    <div class="step">
+      <h3>Android</h3>
+      <ol>
+        <li>Install <a href="https://play.google.com/store/apps/details?id=com.dropbox.android" target="_blank" rel="noopener">Dropbox for Android</a> from the Play Store.</li>
+        <li>Sign in and navigate to your <strong>Projelli</strong> folder.</li>
+        <li>Tap any <code>.md</code> file to read it.</li>
+      </ol>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Dropbox iOS app showing the synced Projelli workspace]</div>
+      <figcaption>TODO: real screenshot of the Dropbox iOS app browsing the Projelli folder.</figcaption>
+    </figure>
+
+    <h2>Limitations to know</h2>
+
+    <div class="warning">
+      <strong>Treat your phone as read-only for now.</strong> Dropbox handles conflicts more gracefully than iCloud (it creates a clearly labeled "conflicted copy" instead of silently making a duplicate), but the cleanest workflow is still to edit on one device at a time.
+    </div>
+
+    <ul>
+      <li><strong>Dropbox free tier is 2 GB.</strong> A Projelli workspace fits easily, but watch out if you also store photos or large files in the same Dropbox account.</li>
+      <li><strong>Smart Sync (selective sync) can hide files from Projelli.</strong> If you've enabled Smart Sync to keep files cloud-only, Projelli won't see them locally. Right-click the Projelli folder in Finder and choose <strong>Make Available Offline</strong> to force a local copy.</li>
+      <li><strong>Sync icons matter.</strong> If you write a file in Projelli and immediately open the phone, the green checkmark on the desktop side confirms the file has finished uploading. Wait for it before checking the phone.</li>
+    </ul>
+
+    <h2>OneDrive note</h2>
+
+    <p>OneDrive works exactly the same way. Install OneDrive on your computer, point Projelli at a folder inside the OneDrive sync folder, and use the OneDrive iOS or Android app to browse on your phone. The steps above translate one for one.</p>
+
+    <h2>What's next</h2>
+
+    <p>If you want a sync option that doesn't depend on a third-party cloud, see the <a href="/docs/mobile-access/syncthing">Syncthing guide</a>. If you have an iPhone and a Mac, the <a href="/docs/mobile-access/icloud">iCloud Drive guide</a> is even simpler.</p>
+
+    <a href="/docs/mobile-access/" class="next-link">Back to Mobile access overview →</a>
+  </div>
+</body>
+</html>

--- a/website/docs/mobile-access/google-drive.html
+++ b/website/docs/mobile-access/google-drive.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Google Drive setup, Projelli</title>
+  <meta name="description" content="Step-by-step: read your Projelli workspace on Android or iPhone using Google Drive. Requires the Google Drive desktop app.">
+  <link rel="canonical" href="https://projelli.com/docs/mobile-access/google-drive">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .step { background: #F8FAFC; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; }
+    .step h3 { margin-top: 0; color: #3B82F6; }
+    .warning { background: #FEF3C7; border-left: 3px solid #F59E0B; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .warning strong { color: #111F35; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+    figure { margin: 24px 0; }
+    figure .placeholder { display: flex; align-items: center; justify-content: center; min-height: 240px; background: #F1F5F9; border: 2px dashed #CBD5E1; border-radius: 8px; color: #94A3B8; font-size: 0.875rem; padding: 24px; text-align: center; }
+    figcaption { color: #94A3B8; font-size: 0.8125rem; margin-top: 8px; text-align: center; font-style: italic; }
+    .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
+    .next-link:hover { text-decoration: none; opacity: 0.9; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+
+<body>
+  <div class="container">
+    <a href="/docs/mobile-access/" class="back">← Back to Mobile access</a>
+    <h1>Google Drive setup</h1>
+    <p class="meta">Best on Android. Works on iOS too. Requires the Google Drive desktop app.</p>
+
+    <p>If you have an Android phone or already pay for Google One, Google Drive is a natural fit. The catch is that Projelli needs to write to a regular folder on your computer, so you must install the <strong>Google Drive for desktop</strong> app and let it mirror Drive to a local folder.</p>
+
+    <h2>Step 1: Install Google Drive for desktop</h2>
+
+    <div class="step">
+      <ol>
+        <li>Download <strong>Google Drive for desktop</strong> from <a href="https://www.google.com/drive/download/" target="_blank" rel="noopener">google.com/drive/download</a>.</li>
+        <li>Install and sign in with your Google account.</li>
+        <li>When asked, choose <strong>Mirror files</strong> (not "Stream files"). Mirror keeps a real local copy of every file, which is what Projelli needs. Stream stores files only in the cloud and downloads on demand, which Projelli can't reliably read from.</li>
+        <li>Pick a local folder for the mirror. The default is <code>~/Library/CloudStorage/GoogleDrive-you@example.com/My Drive/</code> on Mac or <code>G:\My Drive\</code> on Windows.</li>
+      </ol>
+    </div>
+
+    <div class="warning">
+      <strong>The "Mirror files" option is critical.</strong> If you accidentally chose "Stream files," Projelli will see an empty folder or a folder of cloud-only placeholder files it can't open. Re-run the Drive setup wizard and switch to Mirror mode.
+    </div>
+
+    <h2>Step 2: Point Projelli at your Drive folder</h2>
+
+    <div class="step">
+      <ol>
+        <li>In Projelli, open <strong>File → Open Workspace</strong>.</li>
+        <li>Navigate into your mirrored Google Drive folder.</li>
+        <li>Create a folder called <strong>Projelli</strong> inside Drive.</li>
+        <li>Select that folder as your workspace and click <strong>Open</strong>.</li>
+      </ol>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Projelli with workspace pointing at the mirrored Google Drive folder]</div>
+      <figcaption>TODO: real screenshot of Projelli's workspace selector pointing at the Google Drive folder.</figcaption>
+    </figure>
+
+    <h2>Step 3: Wait for sync</h2>
+
+    <p>Open the Drive folder in Finder or File Explorer. The Drive desktop app shows a small status icon next to each file: a green checkmark means uploaded, a spinning arrow means in progress. Markdown files are tiny so this finishes in seconds.</p>
+
+    <h2>Step 4: Open your workspace on your phone</h2>
+
+    <div class="step">
+      <h3>Android</h3>
+      <ol>
+        <li>The Google Drive app comes preinstalled on most Android phones. If it isn't, get it from the <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.docs" target="_blank" rel="noopener">Play Store</a>.</li>
+        <li>Open the app, sign in with the same Google account you use on your computer.</li>
+        <li>Tap <strong>Files</strong> at the bottom, then navigate to your <strong>Projelli</strong> folder.</li>
+        <li>Tap any <code>.md</code> file. Drive on Android renders Markdown as plain text. For nicer rendering, install <a href="https://play.google.com/store/apps/details?id=net.gsantner.markor" target="_blank" rel="noopener">Markor</a> and open the file with that.</li>
+      </ol>
+    </div>
+
+    <div class="step">
+      <h3>iPhone</h3>
+      <ol>
+        <li>Install <a href="https://apps.apple.com/us/app/google-drive/id507874739" target="_blank" rel="noopener">Google Drive for iOS</a> from the App Store.</li>
+        <li>Sign in and navigate to your <strong>Projelli</strong> folder.</li>
+        <li>Tap any <code>.md</code> file to read it. The iOS app renders Markdown as plain text.</li>
+      </ol>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Google Drive Android app showing the synced Projelli workspace]</div>
+      <figcaption>TODO: real screenshot of the Google Drive Android app browsing the Projelli folder.</figcaption>
+    </figure>
+
+    <h2>Limitations to know</h2>
+
+    <div class="warning">
+      <strong>Treat your phone as read-only for now.</strong> Google Drive handles desktop-to-mobile changes well, but mobile-to-desktop edits can take longer to propagate and occasionally need a manual refresh on the desktop side.
+    </div>
+
+    <ul>
+      <li><strong>Free tier is 15 GB</strong> shared across Drive, Gmail, and Photos. A Projelli workspace fits comfortably; just check that your overall Google storage isn't already full.</li>
+      <li><strong>Mirror mode uses local disk space.</strong> Every file in your Drive lives on your hard drive. If your Drive is large and your laptop SSD is small, this matters; you can use Stream mode for the rest of Drive and switch only the Projelli folder to "Available offline" instead.</li>
+      <li><strong>Drive's Android app shows a "Open in" sheet for unrecognized formats.</strong> Tapping a <code>.md</code> file may prompt you to pick an app to open it with. Pick a Markdown reader once and Android remembers your choice.</li>
+    </ul>
+
+    <h2>What's next</h2>
+
+    <p>If you want a setup that works on both iOS and Android with the cleanest mobile reading experience, see the <a href="/docs/mobile-access/dropbox">Dropbox guide</a>. For Apple-only users, the <a href="/docs/mobile-access/icloud">iCloud Drive guide</a> is the simplest path.</p>
+
+    <a href="/docs/mobile-access/" class="next-link">Back to Mobile access overview →</a>
+  </div>
+</body>
+</html>

--- a/website/docs/mobile-access/icloud.html
+++ b/website/docs/mobile-access/icloud.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>iCloud Drive setup, Projelli</title>
+  <meta name="description" content="Step-by-step: read your Projelli workspace on iPhone using iCloud Drive. Five minutes, zero new accounts.">
+  <link rel="canonical" href="https://projelli.com/docs/mobile-access/icloud">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .step { background: #F8FAFC; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; }
+    .step h3 { margin-top: 0; color: #3B82F6; }
+    .warning { background: #FEF3C7; border-left: 3px solid #F59E0B; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .warning strong { color: #111F35; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+    figure { margin: 24px 0; }
+    figure .placeholder { display: flex; align-items: center; justify-content: center; min-height: 240px; background: #F1F5F9; border: 2px dashed #CBD5E1; border-radius: 8px; color: #94A3B8; font-size: 0.875rem; padding: 24px; text-align: center; }
+    figcaption { color: #94A3B8; font-size: 0.8125rem; margin-top: 8px; text-align: center; font-style: italic; }
+    .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
+    .next-link:hover { text-decoration: none; opacity: 0.9; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+
+<body>
+  <div class="container">
+    <a href="/docs/mobile-access/" class="back">← Back to Mobile access</a>
+    <h1>iCloud Drive setup</h1>
+    <p class="meta">For Apple users. About 5 minutes start to finish.</p>
+
+    <p>If you have an iPhone (or iPad) and a Mac signed into the same Apple ID, you already have everything you need. iCloud Drive is built into both. You just need to point Projelli at the right folder.</p>
+
+    <h2>Step 1: Make sure iCloud Drive is on</h2>
+
+    <div class="step">
+      <h3>On your Mac</h3>
+      <ol>
+        <li>Open <strong>System Settings</strong>, click your Apple ID at the top, then click <strong>iCloud</strong>.</li>
+        <li>Make sure <strong>iCloud Drive</strong> is turned on. If it isn't, flip the toggle and wait a moment for it to sync.</li>
+      </ol>
+    </div>
+
+    <div class="step">
+      <h3>On your iPhone</h3>
+      <ol>
+        <li>Open the <strong>Files</strong> app. If you've never used it, it's the blue folder icon that ships with iOS.</li>
+        <li>Tap <strong>Browse</strong> at the bottom. You should see <strong>iCloud Drive</strong> in the list of locations. If it's missing, go to <strong>Settings → [your name] → iCloud → iCloud Drive</strong> and turn it on.</li>
+      </ol>
+    </div>
+
+    <h2>Step 2: Point Projelli at iCloud Drive</h2>
+
+    <div class="step">
+      <h3>In Projelli on your Mac</h3>
+      <ol>
+        <li>Open Projelli. From the menu, choose <strong>File → Open Workspace</strong> (or click the workspace name in the sidebar to switch).</li>
+        <li>In the folder picker, navigate to your iCloud Drive folder. The full path is:<br>
+          <code>~/Library/Mobile Documents/com~apple~CloudDocs/</code>
+        </li>
+        <li>Create a new folder called <strong>Projelli</strong> inside iCloud Drive (or pick an existing folder if you already have one).</li>
+        <li>Select that folder as your workspace and click <strong>Open</strong>.</li>
+      </ol>
+      <p>From this moment on, every file Projelli writes lives inside iCloud Drive and syncs automatically.</p>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Mac Projelli with workspace pointing at iCloud Drive folder]</div>
+      <figcaption>TODO: real screenshot of Projelli's workspace selector pointing at iCloud Drive.</figcaption>
+    </figure>
+
+    <h2>Step 3: Wait for sync</h2>
+
+    <p>The first sync can take anywhere from a few seconds to a few minutes depending on how much is in your workspace. You can watch progress in the Finder: open your iCloud Drive folder and look for the cloud icon next to each file. A solid icon means it's uploading; no icon means it's done.</p>
+
+    <p>If your workspace is brand new and only has a handful of Markdown files, sync should finish in well under a minute.</p>
+
+    <h2>Step 4: Open your workspace on iPhone</h2>
+
+    <div class="step">
+      <ol>
+        <li>On your iPhone, open the <strong>Files</strong> app.</li>
+        <li>Tap <strong>Browse</strong>, then <strong>iCloud Drive</strong>, then your <strong>Projelli</strong> folder.</li>
+        <li>You'll see your workspace exactly as it is on your Mac. Tap any <code>.md</code> file to read it.</li>
+      </ol>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: iPhone Files app showing the synced Projelli workspace]</div>
+      <figcaption>TODO: real screenshot of iPhone Files browsing the Projelli folder in iCloud Drive.</figcaption>
+    </figure>
+
+    <p>iOS Files renders Markdown as plain text. If you want pretty rendering on the phone, install a free Markdown reader from the App Store (Taio, 1Writer, and iA Writer all work well) and point it at the same iCloud Drive folder.</p>
+
+    <h2>Limitations to know</h2>
+
+    <div class="warning">
+      <strong>Treat your phone as read-only for now.</strong> If you edit a file on both your Mac and your phone within a few seconds of each other, iCloud Drive can produce a conflict copy named something like <code>VISION 2.md</code>. To avoid this, pick one device at a time as the editor.
+    </div>
+
+    <ul>
+      <li><strong>iCloud free tier is 5 GB.</strong> A typical Projelli workspace is far under that. If you hit the limit, you can either delete other iCloud content or pay for iCloud+ (starts at 99 cents per month for 50 GB).</li>
+      <li><strong>Sync delay is normally a few seconds, sometimes longer.</strong> If you edit on the desktop and immediately open the phone, you might see the previous version for a moment. Pull down on the Files screen to force-refresh.</li>
+      <li><strong>Wiki-link navigation doesn't work in Files.</strong> The phone shows file contents as plain text. Wiki-links and backlinks are a Projelli feature; they round-trip to the Mac when you tap a file there.</li>
+    </ul>
+
+    <h2>What's next</h2>
+
+    <p>The iCloud Drive workaround is the simplest mobile path on Apple devices. If you also want to sync to non-Apple devices, see the <a href="/docs/mobile-access/dropbox">Dropbox guide</a> or the <a href="/docs/mobile-access/syncthing">Syncthing guide</a>.</p>
+
+    <a href="/docs/mobile-access/" class="next-link">Back to Mobile access overview →</a>
+  </div>
+</body>
+</html>

--- a/website/docs/mobile-access/index.html
+++ b/website/docs/mobile-access/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Access, Projelli</title>
+  <meta name="description" content="Read your Projelli workspace on your phone today using iCloud Drive, Dropbox, Syncthing, or Google Drive. The dedicated mobile reader is in beta.">
+  <link rel="canonical" href="https://projelli.com/docs/mobile-access/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 880px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .callout { background: #F0F9FF; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .callout strong { color: #111F35; }
+    .provider-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin: 24px 0; }
+    .provider-card { display: block; background: #F8FAFC; padding: 24px; border-radius: 8px; border: 1px solid #E2E8F0; text-decoration: none; transition: transform 0.15s ease, box-shadow 0.15s ease; }
+    .provider-card:hover { text-decoration: none; transform: translateY(-2px); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06); }
+    .provider-card h3 { color: #111F35; margin-top: 0; }
+    .provider-card p { color: #475569; font-size: 0.9375rem; margin-bottom: 0; }
+    .provider-card .tag { display: inline-block; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; padding: 2px 8px; border-radius: 999px; margin-bottom: 8px; }
+    .tag-easy { background: #DCFCE7; color: #166534; }
+    .tag-medium { background: #FEF3C7; color: #854D0E; }
+    .tag-advanced { background: #FEE2E2; color: #991B1B; }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.9375rem; }
+    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid #E2E8F0; vertical-align: top; }
+    th { color: #111F35; font-weight: 600; background: #F8FAFC; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+
+<body>
+  <div class="container">
+    <a href="/" class="back">← Back to Projelli</a>
+    <h1>Mobile access</h1>
+    <p class="meta">Read your Projelli workspace on your phone today.</p>
+
+    <p>Projelli is a desktop app, but your workspace is just a folder of plain Markdown files. Point that folder at any cross-device file sync service (iCloud Drive, Dropbox, Syncthing, Google Drive) and your notes show up on your iPhone or Android in whichever Files app you already use. No new account, no extra cost, no waiting on us to ship the dedicated reader.</p>
+
+    <div class="callout">
+      <strong>This is the v2.0 mobile story.</strong> A dedicated Projelli mobile reader is in beta and will land later in the v2.0 cycle. Until then, the cloud sync workaround below is the recommended path. It works today, on every iPhone and Android, with no new app install required.
+    </div>
+
+    <h2>Pick a sync service</h2>
+
+    <div class="provider-grid">
+      <a class="provider-card" href="/docs/mobile-access/icloud">
+        <span class="tag tag-easy">Easiest on Apple</span>
+        <h3>iCloud Drive</h3>
+        <p>If you have an iPhone and a Mac, this is the shortest path. Two clicks on the Mac side, zero setup on the phone.</p>
+      </a>
+      <a class="provider-card" href="/docs/mobile-access/dropbox">
+        <span class="tag tag-easy">Cross-platform</span>
+        <h3>Dropbox</h3>
+        <p>Best if you already pay Dropbox. Works on iOS and Android. Reliable conflict handling.</p>
+      </a>
+      <a class="provider-card" href="/docs/mobile-access/syncthing">
+        <span class="tag tag-advanced">For tinkerers</span>
+        <h3>Syncthing</h3>
+        <p>LAN sync without third-party cloud. Free and open source. More setup, but your data never leaves your devices.</p>
+      </a>
+      <a class="provider-card" href="/docs/mobile-access/google-drive">
+        <span class="tag tag-medium">Cross-platform</span>
+        <h3>Google Drive</h3>
+        <p>Works on Android and iOS. Requires the Google Drive desktop app on your computer for two-way sync.</p>
+      </a>
+    </div>
+
+    <h2>Which one should I pick?</h2>
+
+    <p>Quick decision matrix based on what you already use.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>If you...</th>
+          <th>Pick</th>
+          <th>Why</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Have an iPhone and a Mac, and don't already pay for cloud storage</td>
+          <td><a href="/docs/mobile-access/icloud">iCloud Drive</a></td>
+          <td>Built in, free up to 5 GB, zero new accounts.</td>
+        </tr>
+        <tr>
+          <td>Already pay for Dropbox or use it daily</td>
+          <td><a href="/docs/mobile-access/dropbox">Dropbox</a></td>
+          <td>Most reliable conflict handling of the bunch. Works on iOS and Android.</td>
+        </tr>
+        <tr>
+          <td>Want your data to stay on your own devices, no third-party servers</td>
+          <td><a href="/docs/mobile-access/syncthing">Syncthing</a></td>
+          <td>Peer-to-peer sync over your home network. Open source. More setup.</td>
+        </tr>
+        <tr>
+          <td>Have an Android phone</td>
+          <td><a href="/docs/mobile-access/google-drive">Google Drive</a></td>
+          <td>Tightest Android integration. Works on iOS too.</td>
+        </tr>
+        <tr>
+          <td>Already pay for OneDrive or Microsoft 365</td>
+          <td><a href="/docs/mobile-access/dropbox">Use Dropbox steps as a template</a></td>
+          <td>OneDrive works the same way: point Projelli at your synced OneDrive folder. The Dropbox guide steps map cleanly.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>The shape of the workaround</h2>
+
+    <p>Every guide on this page follows the same three-step shape:</p>
+    <ol>
+      <li><strong>On your computer:</strong> install the sync service's desktop app if you don't already have it. Make sure your sync folder is visible in Finder or File Explorer.</li>
+      <li><strong>In Projelli:</strong> set your workspace folder to a path inside the sync folder. From this moment on, every Markdown file Projelli writes also writes to the cloud.</li>
+      <li><strong>On your phone:</strong> open the sync service's iOS or Android app (Files on iPhone for iCloud; the official Dropbox or Drive app otherwise) and navigate to your workspace folder. Tap any <code>.md</code> file to read it.</li>
+    </ol>
+
+    <h2>Important caveats</h2>
+
+    <p>The workaround is real and it works, but it's not a real-time sync engine. Two things to know:</p>
+    <ul>
+      <li><strong>Treat mobile as read-mostly for now.</strong> If you edit the same file on both your phone and your desktop in quick succession, the sync service can produce a conflict copy. The fix is to pick one device as the editor and use the other to read.</li>
+      <li><strong>Wait for sync to finish before switching devices.</strong> iCloud and Dropbox typically take a few seconds to propagate small Markdown files. If you edit on the desktop and immediately open your phone, you might see the old version for a moment.</li>
+    </ul>
+
+    <p>The dedicated Projelli mobile reader (in beta) solves both of these properly with first-class read access and a content cache. This guide is the workaround that gets you 80% of the value today.</p>
+
+    <h2>Got stuck?</h2>
+
+    <p>Email <a href="mailto:support@projelli.com">support@projelli.com</a> with your sync service of choice and what you tried. Most setup issues are one config tweak away from working.</p>
+  </div>
+</body>
+</html>

--- a/website/docs/mobile-access/screenshots/README.md
+++ b/website/docs/mobile-access/screenshots/README.md
@@ -1,0 +1,31 @@
+# Mobile access screenshots
+
+This folder is reserved for real screenshots of the mobile access workaround.
+The Stream D1 docs ship with placeholder boxes so the launch isn't blocked
+on capturing imagery.
+
+## Slots to fill
+
+When real screenshots are captured, drop them here using these filenames so
+the docs pages can swap `[placeholder box]` for an `<img>` tag in one edit:
+
+- `icloud-mac-projelli.png` — Projelli on Mac with workspace pointing at
+  `~/Library/Mobile Documents/com~apple~CloudDocs/Projelli/`.
+- `icloud-iphone-files.png` — iPhone Files app showing the synced Projelli
+  folder under iCloud Drive.
+- `dropbox-mac-projelli.png` — Projelli on Mac with workspace pointing at
+  the Dropbox folder.
+- `dropbox-ios-app.png` — Dropbox iOS app browsing the Projelli folder.
+- `syncthing-admin.png` — Syncthing web admin with the Projelli folder
+  configured.
+- `syncthing-android.png` — Syncthing-Fork on Android showing the paired
+  Projelli folder.
+- `gdrive-mac-projelli.png` — Projelli on Mac with workspace pointing at
+  the mirrored Google Drive folder.
+- `gdrive-android.png` — Google Drive Android app browsing the Projelli
+  folder.
+
+## Format
+
+PNG, max width 1200 px, optimized with something like `pngquant --quality 70-85`.
+Light theme (matches the rest of the docs).

--- a/website/docs/mobile-access/syncthing.html
+++ b/website/docs/mobile-access/syncthing.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Syncthing setup, Projelli</title>
+  <meta name="description" content="Step-by-step: sync your Projelli workspace to your phone using Syncthing. Open source, peer-to-peer, no third-party cloud.">
+  <link rel="canonical" href="https://projelli.com/docs/mobile-access/syncthing">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .step { background: #F8FAFC; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; }
+    .step h3 { margin-top: 0; color: #3B82F6; }
+    .warning { background: #FEF3C7; border-left: 3px solid #F59E0B; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .warning strong { color: #111F35; }
+    .callout { background: #F0F9FF; border-left: 3px solid #3B82F6; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+    figure { margin: 24px 0; }
+    figure .placeholder { display: flex; align-items: center; justify-content: center; min-height: 240px; background: #F1F5F9; border: 2px dashed #CBD5E1; border-radius: 8px; color: #94A3B8; font-size: 0.875rem; padding: 24px; text-align: center; }
+    figcaption { color: #94A3B8; font-size: 0.8125rem; margin-top: 8px; text-align: center; font-style: italic; }
+    .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
+    .next-link:hover { text-decoration: none; opacity: 0.9; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+
+<body>
+  <div class="container">
+    <a href="/docs/mobile-access/" class="back">← Back to Mobile access</a>
+    <h1>Syncthing setup</h1>
+    <p class="meta">Open source. Peer-to-peer. Your data never touches a third-party cloud.</p>
+
+    <p><a href="https://syncthing.net/" target="_blank" rel="noopener">Syncthing</a> is free, open source, and syncs files directly between your devices over your local network (or the internet, encrypted, when you're away from home). No company stores a copy. The tradeoff is more setup than iCloud or Dropbox, and Syncthing on iOS is currently a third-party paid app.</p>
+
+    <div class="callout">
+      <strong>Pick this if</strong> you care about keeping your notes on your own devices, you're comfortable installing software from open-source projects, and you have at least one Android device or are willing to pay for an iOS Syncthing client.
+    </div>
+
+    <h2>Step 1: Install Syncthing on your computer</h2>
+
+    <div class="step">
+      <ol>
+        <li>Download Syncthing from <a href="https://syncthing.net/downloads/" target="_blank" rel="noopener">syncthing.net/downloads</a> for your platform.</li>
+        <li>Run it. Syncthing opens a web admin page in your browser at <code>http://127.0.0.1:8384</code>.</li>
+        <li>The admin page shows your device's unique ID (a long string starting with letters). You'll need this to pair with your phone.</li>
+      </ol>
+    </div>
+
+    <h2>Step 2: Create a Projelli folder and share it</h2>
+
+    <div class="step">
+      <ol>
+        <li>Decide where your Projelli workspace will live on your computer. A clean choice is <code>~/Projelli-Sync/</code>.</li>
+        <li>In the Syncthing admin page, click <strong>Add Folder</strong>.</li>
+        <li>Folder Label: <code>Projelli</code>. Folder ID: leave the auto-generated value. Folder Path: the path you picked above.</li>
+        <li>Save. Syncthing now watches that folder for changes.</li>
+      </ol>
+    </div>
+
+    <h2>Step 3: Point Projelli at the synced folder</h2>
+
+    <div class="step">
+      <ol>
+        <li>In Projelli, open <strong>File → Open Workspace</strong>.</li>
+        <li>Pick the folder you set up in Syncthing (for example, <code>~/Projelli-Sync/</code>).</li>
+        <li>Click <strong>Open</strong>.</li>
+      </ol>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Syncthing admin page with the Projelli folder configured]</div>
+      <figcaption>TODO: real screenshot of the Syncthing admin page showing a configured Projelli folder.</figcaption>
+    </figure>
+
+    <h2>Step 4: Install Syncthing on your phone</h2>
+
+    <div class="step">
+      <h3>Android (recommended)</h3>
+      <ol>
+        <li>Install <a href="https://play.google.com/store/apps/details?id=com.github.catfriend1.syncthingandroid" target="_blank" rel="noopener">Syncthing-Fork</a> from the Play Store. (The original Syncthing-Android was deprecated; Syncthing-Fork is the maintained successor.)</li>
+        <li>Open the app. Tap the menu, choose <strong>Devices</strong>, then <strong>+</strong> to add a device.</li>
+        <li>Use the device ID from your computer's Syncthing admin page. Your phone will appear on the computer side asking to be approved; approve it.</li>
+        <li>Then on the phone, tap <strong>Folders</strong>, accept the incoming Projelli folder share, and pick a destination on your phone (for example, <code>/storage/emulated/0/Projelli/</code>).</li>
+      </ol>
+    </div>
+
+    <div class="step">
+      <h3>iOS</h3>
+      <p>iOS does not have an official Syncthing client. The community-recommended option is <a href="https://apps.apple.com/us/app/m%C3%B6bius-sync/id1539203216" target="_blank" rel="noopener">Möbius Sync</a> from the App Store. It's a paid app (one-time purchase), and it follows the same pairing flow: add your computer's device ID, accept the Projelli folder share, and pick where to store it on the phone.</p>
+      <p>If you don't want to pay for an iOS Syncthing client, the <a href="/docs/mobile-access/icloud">iCloud Drive workaround</a> is the better fit on iPhone.</p>
+    </div>
+
+    <figure>
+      <div class="placeholder">[Screenshot: Syncthing-Fork on Android with the Projelli folder paired]</div>
+      <figcaption>TODO: real screenshot of Syncthing-Fork on Android showing the paired Projelli folder.</figcaption>
+    </figure>
+
+    <h2>Step 5: Read your files on your phone</h2>
+
+    <p>Once the folder finishes syncing, browse to your Projelli folder using your phone's file manager. On Android, the built-in Files app or Google Files works fine. Tap any <code>.md</code> file to read it (Android renders Markdown as plain text by default; install a free Markdown reader like <a href="https://play.google.com/store/apps/details?id=net.gsantner.markor" target="_blank" rel="noopener">Markor</a> for nicer rendering).</p>
+
+    <h2>Limitations to know</h2>
+
+    <div class="warning">
+      <strong>Treat your phone as read-only for now.</strong> Syncthing handles conflicts by creating a file with <code>.sync-conflict</code> in the name. The cleanest workflow is to edit on one device at a time.
+    </div>
+
+    <ul>
+      <li><strong>Both devices must be running.</strong> Syncthing is peer-to-peer, so files only sync when both your computer and your phone have Syncthing actively running. Sleep your laptop and the sync pauses until it wakes up.</li>
+      <li><strong>iOS Syncthing costs money.</strong> Möbius Sync is a one-time purchase. There is no free official iOS client.</li>
+      <li><strong>First sync can be slow over cellular.</strong> If you're not on the same Wi-Fi network as your computer when you first pair, the initial sync goes over Syncthing's relay servers and can be noticeably slower than local sync.</li>
+    </ul>
+
+    <h2>What's next</h2>
+
+    <p>For a less-technical option that works on both iOS and Android with no extra software cost, see the <a href="/docs/mobile-access/dropbox">Dropbox guide</a>. For Apple-only users, the <a href="/docs/mobile-access/icloud">iCloud Drive guide</a> is the simplest path.</p>
+
+    <a href="/docs/mobile-access/" class="next-link">Back to Mobile access overview →</a>
+  </div>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -2222,6 +2222,7 @@
           <ul>
             <li><a href="/docs/getting-started">Getting Started</a></li>
             <li><a href="/docs/api-keys">API Keys Guide</a></li>
+            <li><a href="/docs/mobile-access/">Mobile access</a></li>
             <li><a href="/docs/faq">FAQ</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="/press-kit/">Press Kit</a></li>


### PR DESCRIPTION
## Summary

Stream D1 ships the v2.0 mobile-access story: workaround documentation for users who want their Projelli workspace on phones today, before the dedicated mobile reader (D2-build) lands. Documents iCloud Drive, Dropbox, Syncthing, and Google Drive setups. Adds an in-app Settings → Mobile page that mirrors the web docs.

- New web docs at `projelli.com/docs/mobile-access/` (hub + 4 provider pages)
- New in-app Settings → Mobile page using shadcn Tabs
- README + FAQ updated with mobile access section

Spec reference: `docs/superpowers/specs/2026-04-28-v2.0-mega-release-design.md` section 7.2
Plan reference: `docs/superpowers/plans/2026-05-03-stream-d1-icloud-docs.md`

## Test plan

- [ ] Visit `https://projelli.com/docs/mobile-access/` and click each provider page; verify content reads cleanly
- [ ] In the desktop app, open Settings → Mobile, switch between the four provider tabs
- [ ] Click any deep-link button (where present) to verify the URL scheme works on macOS / iOS
- [ ] Verify the FAQ at `/docs/faq.html` has the two new mobile-related items
- [ ] Confirm screenshots look reasonable; flag any that need real iOS captures (placeholders are intentional for v2.0 launch)

## Notes

Screenshots are placeholder boxes pending real iOS captures. Replace at your convenience without blocking merge.

Test results: 153 passing in the new + lint surfaces; full suite verified clean before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)