### PR TITLE
feat(stream-c): seed catalog + live community repos (v2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Stream C complete (v2.0): live community catalogs with day-one content.**
+  Two public GitHub repos are now online, seeded, and feeding the in-app
+  Marketplace UI through the install pipeline shipped in C1 + C4:
+  - `projelli/community-templates` (6 entries: beta-user-survey,
+    cold-email-sequence, customer-discovery-interview,
+    investor-update-email-community, launch-announcement-tweet-thread,
+    press-release).
+  - `projelli/community-plugins` (4 entries: mermaid-preview, pomodoro,
+    translator, word-counter, all built from the C5 example plugins).
+  - Catalogs are publicly fetchable at
+    `https://raw.githubusercontent.com/projelli/community-templates/main/catalog.json`
+    and `.../community-plugins/main/catalog.json`. Tarballs are reproducible,
+    SHA-256-pinned, and validated against the in-app Zod manifest schemas.
+  - On opening Settings -> Marketplace -> Templates or Plugins, users see
+    the seeded entries and can install + use them end-to-end (toolbar
+    buttons, sidebar panels, command-palette commands all wire through).
+  - Submission process documented in two places (the live repo READMEs +
+    `projelli.com/docs/marketplace-submissions`).
+  - Capstone PR for Stream C: templates marketplace (C1) + plugin runner
+    (C3) + plugin marketplace UI (C4) + plugin developer experience (C5)
+    + this seed catalog (C6) all working together with live content.
+- **Live-network marketplace integration test (Stream C6, v2.0, Group VI).**
+  New `tests/integration/marketplace-fetch-from-live-repos.test.ts` hits the
+  real `raw.githubusercontent.com` URLs, verifies both catalogs parse as
+  `CatalogEntry[]`, downloads one real tarball from each, confirms the
+  actual SHA-256 matches the catalog-declared checksum (catches bot drift
+  or a tampered repo), and validates a real `manifest.json` from each
+  repo against the in-app Zod schema. Gated behind `LIVE_NETWORK_OK=1` so
+  CI stays offline; Jameson runs it manually after seeding new entries.
 - **Seed catalog source-of-truth Action workflow + script (Stream C6, v2.0,
   Group I).** New `infra/community-repos/build-catalog.mjs` is a Node 22 ESM
   script that walks `entries/<id>/`, validates each `manifest.json` against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Seed catalog source-of-truth Action workflow + script (Stream C6, v2.0,
+  Group I).** New `infra/community-repos/build-catalog.mjs` is a Node 22 ESM
+  script that walks `entries/<id>/`, validates each `manifest.json` against
+  vendored Zod schemas (templates schema mirrors
+  `src/modules/marketplace/manifestValidator.ts`; plugins schema mirrors
+  `src/modules/plugins/PluginManifestSchema.ts`), builds reproducible
+  per-entry tarballs (sorted, fixed mtime, owner/group 0), computes SHA-256,
+  and writes `catalog.json` at the repo root with stable id-sorted ordering.
+  Selectable via `PROJELLI_CATALOG_KIND=templates|plugins`. Tarballs are
+  byte-identical across reruns when content is unchanged. Companion
+  `infra/community-repos/build-catalog.yml` is the GitHub Action that runs
+  the script on every push to `main`, autodetects kind from the repo name,
+  and commits regenerated `catalog.json` + tarballs back with `[skip ci]`
+  to avoid loops. Both files are pushed verbatim by the C6 sync tooling
+  to `projelli/community-templates` and `projelli/community-plugins`.
+- **Marketplace submission docs (Stream C6, v2.0, Group II).** Source-of-truth
+  READMEs for the live community repos at
+  `infra/community-repos/templates-readme.md` and
+  `infra/community-repos/plugins-readme.md`. Plugin README adds a
+  permissions-deep-dive section. Public-facing docs page at
+  `website/docs/marketplace-submissions.html` cross-links both repos and
+  walks through the fork + add entry + PR + review flow. Updated
+  `website/docs/plugins/publishing.html` with a prominent GitHub fork CTA
+  and a cross-link to `/docs/marketplace-submissions`; replaced the old
+  `npm run verify` instructions (which referenced a non-existent script)
+  with the real `PROJELLI_CATALOG_KIND=plugins node scripts/build-catalog.mjs`
+  flow. Added `docs/marketplace-submissions.html` to the website lint
+  TARGETS so it stays voice-clean and canonical-tagged.
 - **Stream C5 plugin developer experience, complete (v2.0).** Third-party
   developers can now `npx create-projelli-plugin <name>` to scaffold a
   ready-to-build TypeScript plugin project, code against the typed

--- a/infra/community-repos/build-catalog.mjs
+++ b/infra/community-repos/build-catalog.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+// projelli/projelli build-catalog.mjs
+//
+// Source of truth for the catalog-rebuild script that lives inside both
+// community repos at scripts/build-catalog.mjs. The sync-to-github tooling
+// copies this file verbatim into each repo, which is why the schema lives
+// inline in this file rather than imported from the projelli app source.
+//
+// WHY the schemas are inlined (not imported):
+//   The community repos are independent and run this script under GitHub
+//   Actions with no access to the projelli app. So we vendor the Zod
+//   manifest schemas here. This file MUST be kept in lockstep with:
+//     - src/modules/marketplace/manifestValidator.ts (templates)
+//     - src/modules/plugins/PluginManifestSchema.ts  (plugins)
+//   Drift between them lets bad manifests reach end-users. The C6 sync
+//   script regenerates this file from the app source before pushing to
+//   the live repos.
+//
+// What this script does (per spec §6.8 and the Stream C6 plan):
+//   1. Walks ./entries/<id>/.
+//   2. For each entry: reads manifest.json, validates with the Zod schema
+//      (templates or plugins, picked by env var PROJELLI_CATALOG_KIND).
+//   3. Builds a deterministic tarball of the entry (excluding the
+//      pre-existing tarball.tar.gz and checksum.txt) into
+//      entries/<id>/tarball.tar.gz.
+//   4. Computes SHA-256 of the tarball, writes entries/<id>/checksum.txt.
+//   5. Generates ./catalog.json with all valid entries' CatalogEntry
+//      shapes, sorted alphabetically by id for stable diffs.
+//
+// Local invocation just writes files. The GitHub Action commits + pushes.
+//
+// Usage:
+//   PROJELLI_CATALOG_KIND=templates node scripts/build-catalog.mjs
+//   PROJELLI_CATALOG_KIND=plugins   node scripts/build-catalog.mjs
+//
+// Optional env:
+//   PROJELLI_CATALOG_REPO  Defaults to inferred owner/name from $GITHUB_REPOSITORY,
+//                          falling back to "projelli/community-templates" or
+//                          "projelli/community-plugins" depending on KIND.
+//   PROJELLI_CATALOG_REF   Branch/ref the URLs should point at. Defaults to "main".
+//   PROJELLI_CATALOG_ROOT  Path to the repo root the script should walk. Defaults
+//                          to the current working directory.
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Vendored Zod schemas (must match projelli app source)
+// ---------------------------------------------------------------------------
+
+const semverRegex = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+const TEMPLATE_FILE_TYPES = ['markdown', 'interview-questions', 'workflow-definition'];
+
+const templateFileEntrySchema = z.object({
+  path: z.string().min(1, 'file.path required'),
+  type: z.enum(TEMPLATE_FILE_TYPES),
+});
+
+const templateAuthorSchema = z.object({
+  name: z.string().min(1, 'author.name required'),
+  githubUser: z.string().min(1).optional(),
+  url: z.url('author.url must be a URL').optional(),
+});
+
+const templateManifestSchema = z.object({
+  id: z.string().min(1, 'id required'),
+  name: z.string().min(1, 'name required'),
+  version: z.string().regex(semverRegex, 'version must be semver'),
+  apiVersion: z.string().min(1, 'apiVersion required'),
+  author: templateAuthorSchema,
+  description: z.string().min(1, 'description required'),
+  category: z.string().min(1, 'category required'),
+  tags: z.array(z.string()),
+  screenshots: z.array(z.string().min(1)).optional(),
+  files: z.array(templateFileEntrySchema).min(1, 'files must contain at least one entry'),
+  minProjelliVersion: z.string().regex(semverRegex, 'minProjelliVersion must be semver'),
+  maxProjelliVersion: z.string().regex(semverRegex, 'maxProjelliVersion must be semver').optional(),
+});
+
+const PLUGIN_PERMISSIONS = [
+  'workspace:read',
+  'workspace:write',
+  'editor:selection',
+  'editor:write',
+  'ai:invoke',
+  'network',
+];
+
+const pluginPermissionSchema = z.enum(PLUGIN_PERMISSIONS);
+
+const pluginAuthorSchema = z.object({
+  name: z.string().min(1, 'author.name required'),
+  githubUser: z.string().min(1).optional(),
+  url: z.url('author.url must be a URL').optional(),
+});
+
+const pluginManifestSchema = z.object({
+  id: z.string().min(1, 'id required'),
+  name: z.string().min(1, 'name required'),
+  version: z.string().regex(semverRegex, 'version must be semver'),
+  apiVersion: z.string().min(1, 'apiVersion required'),
+  author: pluginAuthorSchema,
+  description: z.string().min(1, 'description required'),
+  main: z.string().min(1, 'main required'),
+  permissions: z.array(pluginPermissionSchema),
+  minProjelliVersion: z.string().regex(semverRegex, 'minProjelliVersion must be semver'),
+  maxProjelliVersion: z.string().regex(semverRegex, 'maxProjelliVersion must be semver').optional(),
+  category: z.string().min(1, 'category required'),
+  tags: z.array(z.string()),
+  screenshots: z.array(z.string().min(1)).optional(),
+  homepage: z.url('homepage must be a URL').optional(),
+  license: z.string().min(1).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const KIND = process.env.PROJELLI_CATALOG_KIND;
+if (KIND !== 'templates' && KIND !== 'plugins') {
+  console.error(
+    'PROJELLI_CATALOG_KIND must be "templates" or "plugins". Got:',
+    KIND ?? '<unset>',
+  );
+  process.exit(1);
+}
+
+const REPO_ROOT = resolve(process.env.PROJELLI_CATALOG_ROOT ?? process.cwd());
+const ENTRIES_DIR = join(REPO_ROOT, 'entries');
+const REF = process.env.PROJELLI_CATALOG_REF ?? 'main';
+
+function inferRepo() {
+  if (process.env.PROJELLI_CATALOG_REPO) return process.env.PROJELLI_CATALOG_REPO;
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  return KIND === 'templates' ? 'projelli/community-templates' : 'projelli/community-plugins';
+}
+const REPO = inferRepo();
+
+// Fixed mtime for reproducible tarballs. Real bytes change only when entry
+// contents change, so SHA-256 stays stable across CI runs.
+const REPRODUCIBLE_MTIME = '2026-01-01 00:00:00 UTC';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function listEntryDirs() {
+  if (!existsSync(ENTRIES_DIR)) return [];
+  return readdirSync(ENTRIES_DIR)
+    .filter((name) => {
+      const abs = join(ENTRIES_DIR, name);
+      try {
+        return statSync(abs).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function validateManifest(raw) {
+  const schema = KIND === 'templates' ? templateManifestSchema : pluginManifestSchema;
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((i) => {
+      const p = i.path.join('.') || '<root>';
+      return `${p}: ${i.message}`;
+    });
+    return { ok: false, errors };
+  }
+  return { ok: true, manifest: parsed.data };
+}
+
+function rawUrl(repo, ref, repoRelativePath) {
+  return `https://raw.githubusercontent.com/${repo}/${ref}/${repoRelativePath}`;
+}
+
+/**
+ * Build a deterministic tarball of the entry directory. We copy the entry's
+ * payload into a temp dir (skipping tarball.tar.gz and checksum.txt to avoid
+ * including stale build outputs from previous runs), then tar that. The
+ * `--mtime`, `--sort=name`, `--owner`, `--group`, `--numeric-owner` flags
+ * make the byte output reproducible across machines and CI runs.
+ */
+function buildTarball(entryAbsDir, entryId) {
+  const stagingRoot = mkdtempSync(join(tmpdir(), `projelli-catalog-${entryId}-`));
+  const stagingEntry = join(stagingRoot, entryId);
+  spawnSync('mkdir', ['-p', stagingEntry], { stdio: 'inherit' });
+
+  // Copy everything except the build outputs themselves.
+  const cpResult = spawnSync(
+    'sh',
+    [
+      '-c',
+      // -a preserves mode + symlinks; the trailing /. copies dotfiles too.
+      `cp -a "${entryAbsDir}/." "${stagingEntry}/" && rm -f "${stagingEntry}/tarball.tar.gz" "${stagingEntry}/checksum.txt"`,
+    ],
+    { stdio: 'inherit' },
+  );
+  if (cpResult.status !== 0) {
+    rmSync(stagingRoot, { recursive: true, force: true });
+    throw new Error(`Failed to stage entry ${entryId} for tar`);
+  }
+
+  const tarballPath = join(entryAbsDir, 'tarball.tar.gz');
+  const tarResult = spawnSync(
+    'tar',
+    [
+      '--sort=name',
+      `--mtime=${REPRODUCIBLE_MTIME}`,
+      '--owner=0',
+      '--group=0',
+      '--numeric-owner',
+      '-czf',
+      tarballPath,
+      '-C',
+      stagingRoot,
+      entryId,
+    ],
+    { stdio: 'inherit' },
+  );
+
+  rmSync(stagingRoot, { recursive: true, force: true });
+
+  if (tarResult.status !== 0) {
+    throw new Error(`tar failed for ${entryId}`);
+  }
+  return tarballPath;
+}
+
+function sha256OfFile(path) {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(path));
+  return hash.digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const dirs = listEntryDirs();
+  console.log(`[build-catalog] kind=${KIND} repo=${REPO} ref=${REF} entries=${dirs.length}`);
+
+  const catalogEntries = [];
+  const errors = [];
+
+  for (const id of dirs) {
+    const entryDir = join(ENTRIES_DIR, id);
+    const manifestPath = join(entryDir, 'manifest.json');
+
+    if (!existsSync(manifestPath)) {
+      errors.push(`${id}: missing manifest.json`);
+      continue;
+    }
+
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    } catch (err) {
+      errors.push(`${id}: manifest.json parse error: ${err.message}`);
+      continue;
+    }
+
+    const result = validateManifest(raw);
+    if (!result.ok) {
+      for (const e of result.errors) errors.push(`${id}: ${e}`);
+      continue;
+    }
+    const manifest = result.manifest;
+
+    if (manifest.id !== id) {
+      errors.push(`${id}: manifest.id "${manifest.id}" does not match folder name`);
+      continue;
+    }
+
+    let tarballPath;
+    try {
+      tarballPath = buildTarball(entryDir, id);
+    } catch (err) {
+      errors.push(`${id}: ${err.message}`);
+      continue;
+    }
+
+    const checksum = sha256OfFile(tarballPath);
+    writeFileSync(join(entryDir, 'checksum.txt'), `${checksum}\n`, 'utf-8');
+
+    const screenshotsRel = (manifest.screenshots ?? []).map((s) =>
+      rawUrl(REPO, REF, `entries/${id}/${s}`),
+    );
+
+    const now = new Date().toISOString();
+
+    /** @type {Record<string, unknown>} */
+    const catalogEntry = {
+      id: manifest.id,
+      name: manifest.name,
+      description: manifest.description,
+      version: manifest.version,
+      author: manifest.author,
+      category: manifest.category,
+      tags: manifest.tags,
+      installUrl: rawUrl(REPO, REF, `entries/${id}/tarball.tar.gz`),
+      manifestUrl: rawUrl(REPO, REF, `entries/${id}/manifest.json`),
+      minProjelliVersion: manifest.minProjelliVersion,
+      publishedAt: now,
+      updatedAt: now,
+      checksum,
+    };
+    if (screenshotsRel.length > 0) catalogEntry.screenshots = screenshotsRel;
+    if (manifest.maxProjelliVersion) catalogEntry.maxProjelliVersion = manifest.maxProjelliVersion;
+
+    catalogEntries.push(catalogEntry);
+    console.log(`[build-catalog] ok: ${id} v${manifest.version} sha256=${checksum.slice(0, 12)}...`);
+  }
+
+  if (errors.length > 0) {
+    console.error(`\n[build-catalog] ${errors.length} validation error(s):`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  catalogEntries.sort((a, b) => a.id.localeCompare(b.id));
+
+  const catalogPath = join(REPO_ROOT, 'catalog.json');
+  writeFileSync(catalogPath, `${JSON.stringify(catalogEntries, null, 2)}\n`, 'utf-8');
+  console.log(`\n[build-catalog] wrote ${catalogPath} (${catalogEntries.length} entries)`);
+}
+
+main();

--- a/infra/community-repos/build-catalog.yml
+++ b/infra/community-repos/build-catalog.yml
@@ -1,0 +1,81 @@
+# Source-of-truth GitHub Actions workflow for the projelli community repos
+# (community-templates, community-plugins). The C6 sync script copies this
+# file into both repos at .github/workflows/build-catalog.yml.
+#
+# Trigger: any push to main that touches entries/. The script regenerates
+# catalog.json and per-entry tarballs, then commits the result back to main
+# with [skip ci] so the next push doesn't loop.
+#
+# The schema vendored in scripts/build-catalog.mjs MUST match the projelli
+# app's source schemas. The C6 sync script regenerates that file from the
+# app source before pushing here, so any drift is caught at sync time.
+
+name: Build catalog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'entries/**'
+      - 'scripts/build-catalog.mjs'
+      - '.github/workflows/build-catalog.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-catalog-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install zod (required by build-catalog.mjs)
+        run: |
+          npm init -y > /dev/null
+          npm install --no-save --no-audit --no-fund zod@^4.3.6
+
+      - name: Detect catalog kind from repo name
+        id: kind
+        run: |
+          name="${GITHUB_REPOSITORY##*/}"
+          case "$name" in
+            community-templates) echo "kind=templates" >> "$GITHUB_OUTPUT" ;;
+            community-plugins)   echo "kind=plugins"   >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "Unknown repo name '$name'; expected community-templates or community-plugins" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Build catalog
+        env:
+          PROJELLI_CATALOG_KIND: ${{ steps.kind.outputs.kind }}
+          PROJELLI_CATALOG_REPO: ${{ github.repository }}
+          PROJELLI_CATALOG_REF: ${{ github.ref_name }}
+        run: node scripts/build-catalog.mjs
+
+      - name: Commit + push regenerated catalog
+        run: |
+          git config user.name "projelli-catalog-bot"
+          git config user.email "bot@projelli.com"
+          git add catalog.json entries/*/tarball.tar.gz entries/*/checksum.txt
+          if git diff --staged --quiet; then
+            echo "No catalog changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(catalog): rebuild [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}

--- a/infra/community-repos/plugins-readme.md
+++ b/infra/community-repos/plugins-readme.md
@@ -1,0 +1,152 @@
+# projelli/community-plugins
+
+The community catalog of plugins for [Projelli](https://projelli.com).
+
+Anything in this repo's `entries/` folder shows up in the in-app marketplace under Plugins. Users browse, install with one click, and the plugin's worker spins up inside Projelli's sandboxed runtime.
+
+## What's in here
+
+- `entries/<id>/` — one folder per plugin, each with a manifest, the built JS bundle, and screenshots.
+- `catalog.json` — the marketplace index. Auto-generated from `entries/` on every push to `main`. Never hand-edit.
+- `scripts/build-catalog.mjs` — the script that regenerates `catalog.json` and per-entry tarballs. Runs in CI; you can also run it locally to validate your submission before opening a PR.
+- `.github/workflows/build-catalog.yml` — the GitHub Action that runs the script on every merge.
+
+## How to submit a plugin
+
+### 1. Build your plugin
+
+Follow the [Projelli plugin docs](https://projelli.com/docs/plugins/getting-started) to scaffold and build a plugin. The output is a `manifest.json` and a `dist/index.js` (the bundled worker entry).
+
+### 2. Fork this repo
+
+```
+gh repo fork projelli/community-plugins
+```
+
+Or click Fork on github.com.
+
+### 3. Add your entry
+
+Create a folder under `entries/` whose name matches the `id` in your manifest:
+
+```
+entries/my-plugin/
+├── manifest.json
+├── index.js          (your built bundle, copied from dist/)
+└── screenshots/
+    └── main.png
+```
+
+The folder name MUST match `manifest.id` exactly. The build script enforces this.
+
+### 4. Author the manifest
+
+Your `manifest.json` follows the [PluginManifest schema](https://github.com/projelli/projelli/blob/master/src/types/plugin.ts). Required fields:
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": { "name": "Your Name", "githubUser": "your-handle" },
+  "description": "One-sentence pitch for what this plugin does.",
+  "main": "index.js",
+  "permissions": ["editor:selection"],
+  "minProjelliVersion": "2.0.0",
+  "category": "writing",
+  "tags": ["editor", "stats"],
+  "screenshots": ["screenshots/main.png"],
+  "license": "MIT",
+  "homepage": "https://github.com/your-handle/my-plugin"
+}
+```
+
+`screenshots` paths are relative to your entry folder. They get rewritten to absolute `raw.githubusercontent.com/...` URLs when the catalog builds.
+
+### 5. Validate locally
+
+```
+npm install --no-save zod@^4.3.6
+PROJELLI_CATALOG_KIND=plugins node scripts/build-catalog.mjs
+```
+
+If your manifest validates, the script writes `catalog.json` plus `entries/my-plugin/tarball.tar.gz` and `entries/my-plugin/checksum.txt`. If it fails, you'll see a list of validation errors. Fix and re-run.
+
+You can leave the generated tarball + checksum out of your PR; the Action regenerates them after merge.
+
+### 6. Open a PR
+
+```
+git checkout -b add-my-plugin
+git add entries/my-plugin/
+git commit -m "Add my-plugin v1.0.0"
+git push origin add-my-plugin
+gh pr create --base main
+```
+
+PR title format: `Add <plugin-name> v<version>`.
+
+In the description, include:
+
+- One paragraph explaining what the plugin does.
+- The list of permissions you declare and why each is needed.
+- Any external services your plugin contacts (if you declare `network`).
+- A link to your plugin's source repo if it's public.
+
+## Permissions
+
+Plugins run inside a sandboxed worker and can only do what they declare in `permissions`. The full set:
+
+| Permission | Allows |
+|---|---|
+| `workspace:read` | List + read files in the user's workspace |
+| `workspace:write` | Create, modify, and delete files |
+| `editor:selection` | Read the current editor selection |
+| `editor:write` | Replace the selection or insert text at the cursor |
+| `ai:invoke` | Call the user's configured AI provider on their behalf |
+| `network` | Make outbound HTTP requests to arbitrary URLs |
+
+UI-only capabilities (commands, toolbar buttons, sidebar panels, settings pages, notifications, plugin-local storage) are unconditional and don't require a permission.
+
+### Why minimal permissions matter
+
+Every permission you declare is shown to the user in a consent dialog at install time. Users see exactly what your plugin can do before they accept. A plugin that asks for `workspace:write` and `network` together is asking for a lot of trust. A plugin that asks for `editor:selection` only is easy to trust.
+
+Practical rules:
+
+- **Don't ask for what you won't use.** If your plugin reads the selection but never writes back, declare `editor:selection` and not `editor:write`.
+- **Pick the narrowest scope that works.** `editor:selection` is narrower than `workspace:read` for a plugin that only needs the current paragraph.
+- **Justify `network` and `ai:invoke` in the README.** These are the two permissions users scrutinize hardest. Tell them which hosts you contact and what you send.
+- **Don't use `workspace:write` to fake `editor:write`.** They look similar but the consent UX is very different.
+
+The reviewer will push back on any permission that isn't justified by the plugin's actual behavior.
+
+## Review criteria
+
+A maintainer reviews every submission. We check for:
+
+- **Schema validity.** The Action runs `build-catalog.mjs` on every PR. If it fails, the PR can't merge.
+- **Permissions match behavior.** What you declare matches what the bundle actually does. We read the bundle. If it's obfuscated, we reject.
+- **No secrets in the bundle.** No hardcoded API keys, tokens, or credentials.
+- **Code is readable.** We need to be able to audit the bundle. Source maps or a linked source repo help.
+- **Description matches behavior.** The plugin does what the README says it does, no more.
+- **Reasonable scope.** Plugins that do one focused thing land faster than plugins that try to do everything.
+
+Most reviews finish within a few days. Push another commit to the same branch if we ask for changes.
+
+## License
+
+By submitting a plugin, you agree to publish it under MIT or a compatible permissive license (Apache-2.0, BSD-3-Clause, ISC). Add a `LICENSE` file inside your entry folder if you want to be explicit. Closed-source plugins aren't accepted.
+
+## Reporting a malicious plugin
+
+If you find a plugin in the marketplace doing something it shouldn't (asking for permissions it doesn't need, exfiltrating data, hiding behavior in the bundle), open an issue with the plugin id and what you observed. We take takedowns seriously and will pull entries that violate the trust model.
+
+## Updating an existing plugin
+
+Bump `version` in your manifest, replace `index.js` with the new build, and open a PR with the changes. The catalog always serves the latest version.
+
+## Removing a plugin
+
+Open a PR that deletes the entry folder. Existing installs in user copies of Projelli keep working; the plugin just disappears from the marketplace.

--- a/infra/community-repos/seed-plugins/mermaid-preview/index.js
+++ b/infra/community-repos/seed-plugins/mermaid-preview/index.js
@@ -1,0 +1,89 @@
+const POLL_MS = 1e3;
+const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.esm.min.mjs";
+const FENCE = /```mermaid\s*\n([\s\S]*?)```/g;
+function extractDiagrams(content) {
+  const out = [];
+  let match;
+  let i = 0;
+  FENCE.lastIndex = 0;
+  while ((match = FENCE.exec(content)) !== null) {
+    const source = (match[1] ?? "").trim();
+    if (source) out.push({ index: i, source });
+    i += 1;
+  }
+  return out;
+}
+function escapeHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+function renderEmptyPanel() {
+  return [
+    '<div style="font-family: system-ui, -apple-system, sans-serif; padding: 20px; color: #6b7280;">',
+    '<h2 style="margin: 0 0 12px; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">Mermaid Preview</h2>',
+    '<p style="font-size: 13px; line-height: 1.5;">No mermaid blocks found in the active document. Add one with:</p>',
+    '<pre style="background: #f3f4f6; padding: 10px; border-radius: 4px; font-size: 12px; color: #374151;">```mermaid\nflowchart LR\n  A --&gt; B\n```</pre>',
+    "</div>"
+  ].join("");
+}
+function renderDiagramPanel(diagrams) {
+  const blocks = diagrams.map(
+    (d) => `<div style="margin-bottom: 16px;"><div style="font-size: 11px; color: #9ca3af; margin-bottom: 6px;">Diagram ${d.index + 1}</div><pre class="mermaid" style="background: white; padding: 12px; border: 1px solid #e5e7eb; border-radius: 4px;">${escapeHtml(d.source)}</pre></div>`
+  ).join("");
+  const renderCall = `mermaid.run({ querySelector: 'pre.mermaid' })`;
+  const script = `<script type="module">
+    import mermaid from '${MERMAID_CDN}';
+    mermaid.initialize({ startOnLoad: false, theme: 'default', securityLevel: 'strict' });
+    ${renderCall}.catch(function(e) {
+      const wrap = document.createElement('div');
+      wrap.style.cssText = 'color:#b91c1c;font-size:12px;padding:8px;background:#fef2f2;border-radius:4px;margin-top:8px;';
+      wrap.textContent = 'Mermaid render error: ' + (e && e.message ? e.message : String(e));
+      document.body.appendChild(wrap);
+    });
+  <\/script>`;
+  return [
+    '<div style="font-family: system-ui, -apple-system, sans-serif; padding: 20px; color: #1f2937;">',
+    '<h2 style="margin: 0 0 16px; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">Mermaid Preview</h2>',
+    blocks,
+    script,
+    "</div>"
+  ].join("");
+}
+const plugin = {
+  async activate(api) {
+    let lastSerialized = "";
+    const refresh = async () => {
+      let content = "";
+      try {
+        content = await api.editor.getContent();
+      } catch {
+      }
+      const diagrams = extractDiagrams(content);
+      const serialized = JSON.stringify(diagrams);
+      if (serialized === lastSerialized) return;
+      lastSerialized = serialized;
+      api.sidebar.addPanel({
+        id: "mermaid-preview-panel",
+        title: "Mermaid Preview",
+        html: diagrams.length === 0 ? renderEmptyPanel() : renderDiagramPanel(diagrams)
+      });
+    };
+    api.commands.register("mermaid-preview.refresh", async () => {
+      lastSerialized = "";
+      await refresh();
+      api.notify.info("Mermaid preview refreshed.");
+    });
+    api.toolbar.addButton({
+      id: "mermaid-preview-button",
+      icon: "workflow",
+      tooltip: "Refresh mermaid preview",
+      command: "mermaid-preview.refresh"
+    });
+    await refresh();
+    setInterval(() => {
+      void refresh();
+    }, POLL_MS);
+  }
+};
+export {
+  plugin as default
+};

--- a/infra/community-repos/seed-plugins/mermaid-preview/manifest.json
+++ b/infra/community-repos/seed-plugins/mermaid-preview/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "mermaid-preview",
+  "name": "Mermaid Preview",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": {
+    "name": "Projelli Examples",
+    "githubUser": "projelli",
+    "url": "https://projelli.com"
+  },
+  "description": "Renders fenced mermaid code blocks from the active document into a live diagram preview in the sidebar.",
+  "main": "index.js",
+  "permissions": ["editor:selection"],
+  "minProjelliVersion": "2.0.0",
+  "category": "writing",
+  "tags": ["editor", "diagrams", "mermaid", "preview"],
+  "screenshots": ["screenshots/preview.png"],
+  "homepage": "https://projelli.com/docs/plugins/examples.html",
+  "license": "MIT"
+}

--- a/infra/community-repos/seed-plugins/mermaid-preview/screenshots/README.md
+++ b/infra/community-repos/seed-plugins/mermaid-preview/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest currently references
+`screenshots/preview.png` as a placeholder. Real screenshots can replace it
+without manifest changes as long as the filename stays the same.

--- a/infra/community-repos/seed-plugins/pomodoro/index.js
+++ b/infra/community-repos/seed-plugins/pomodoro/index.js
@@ -1,0 +1,152 @@
+const STORAGE_KEY = "pomodoro:state";
+const WORK_MINUTES = 25;
+const BREAK_MINUTES = 5;
+const TICK_MS = 1e3;
+function defaultState() {
+  return {
+    phase: "work",
+    remainingMs: WORK_MINUTES * 60 * 1e3,
+    running: false,
+    cyclesCompleted: 0,
+    lastResumedAt: null
+  };
+}
+function durationFor(phase) {
+  return (phase === "work" ? WORK_MINUTES : BREAK_MINUTES) * 60 * 1e3;
+}
+function formatRemaining(ms) {
+  const total = Math.max(0, Math.floor(ms / 1e3));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+function tickState(state, now) {
+  if (!state.running || state.lastResumedAt === null) return state;
+  const elapsed = now - state.lastResumedAt;
+  const remaining = state.remainingMs - elapsed;
+  if (remaining > 0) {
+    return { ...state, remainingMs: remaining, lastResumedAt: now };
+  }
+  const nextPhase = state.phase === "work" ? "break" : "work";
+  return {
+    phase: nextPhase,
+    remainingMs: durationFor(nextPhase),
+    running: false,
+    cyclesCompleted: state.cyclesCompleted + (state.phase === "work" ? 1 : 0),
+    lastResumedAt: null
+  };
+}
+function isValidState(value) {
+  if (!value || typeof value !== "object") return false;
+  const v = value;
+  return (v.phase === "work" || v.phase === "break") && typeof v.remainingMs === "number" && typeof v.running === "boolean" && typeof v.cyclesCompleted === "number" && (v.lastResumedAt === null || typeof v.lastResumedAt === "number");
+}
+function renderPanelHtml(state) {
+  const accent = state.phase === "work" ? "#dc2626" : "#16a34a";
+  const phaseLabel = state.phase === "work" ? "Focus" : "Break";
+  const status = state.running ? "Running" : state.remainingMs === durationFor(state.phase) ? "Ready" : "Paused";
+  return [
+    '<div style="font-family: system-ui, -apple-system, sans-serif; padding: 20px; color: #1f2937; text-align: center;">',
+    `<div style="font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: ${accent};">${phaseLabel}</div>`,
+    `<div style="font-size: 56px; font-weight: 700; line-height: 1; margin: 12px 0; font-variant-numeric: tabular-nums; color: ${accent};">${formatRemaining(state.remainingMs)}</div>`,
+    `<div style="font-size: 12px; color: #6b7280; margin-bottom: 16px;">${status} &middot; ${state.cyclesCompleted} cycle${state.cyclesCompleted === 1 ? "" : "s"} completed</div>`,
+    '<div style="font-size: 11px; color: #9ca3af; line-height: 1.6;">',
+    "Use the toolbar buttons or the command palette:<br>",
+    "<code>pomodoro.start</code><br>",
+    "<code>pomodoro.pause</code><br>",
+    "<code>pomodoro.reset</code>",
+    "</div>",
+    "</div>"
+  ].join("");
+}
+const plugin = {
+  async activate(api) {
+    let state = defaultState();
+    try {
+      const stored = await api.storage.get(STORAGE_KEY);
+      if (isValidState(stored)) {
+        state = { ...stored, running: false, lastResumedAt: null };
+      }
+    } catch {
+    }
+    const persist = async () => {
+      try {
+        await api.storage.set(STORAGE_KEY, state);
+      } catch {
+      }
+    };
+    const renderPanel = () => {
+      api.sidebar.addPanel({
+        id: "pomodoro-panel",
+        title: "Pomodoro",
+        html: renderPanelHtml(state)
+      });
+    };
+    renderPanel();
+    api.commands.register("pomodoro.start", async () => {
+      if (state.running) return state;
+      state = { ...state, running: true, lastResumedAt: Date.now() };
+      await persist();
+      renderPanel();
+      api.notify.info(`Pomodoro: ${state.phase === "work" ? "focus" : "break"} timer started.`);
+      return state;
+    });
+    api.commands.register("pomodoro.pause", async () => {
+      if (!state.running) return state;
+      const now = Date.now();
+      const ticked = tickState(state, now);
+      state = { ...ticked, running: false, lastResumedAt: null };
+      await persist();
+      renderPanel();
+      api.notify.info("Pomodoro: paused.");
+      return state;
+    });
+    api.commands.register("pomodoro.reset", async () => {
+      state = { ...defaultState(), cyclesCompleted: state.cyclesCompleted };
+      await persist();
+      renderPanel();
+      api.notify.info("Pomodoro: reset to 25:00.");
+      return state;
+    });
+    api.toolbar.addButton({
+      id: "pomodoro-start-button",
+      icon: "play",
+      tooltip: "Start pomodoro timer",
+      command: "pomodoro.start"
+    });
+    api.toolbar.addButton({
+      id: "pomodoro-pause-button",
+      icon: "pause",
+      tooltip: "Pause pomodoro timer",
+      command: "pomodoro.pause"
+    });
+    api.toolbar.addButton({
+      id: "pomodoro-reset-button",
+      icon: "rotate-ccw",
+      tooltip: "Reset pomodoro timer",
+      command: "pomodoro.reset"
+    });
+    setInterval(() => {
+      if (!state.running) return;
+      const now = Date.now();
+      const previousPhase = state.phase;
+      const next = tickState(state, now);
+      if (next.phase !== previousPhase) {
+        state = next;
+        void persist();
+        renderPanel();
+        if (next.phase === "break") {
+          api.notify.info("Pomodoro: focus session complete. Take a 5-minute break.");
+        } else {
+          api.notify.info("Pomodoro: break over. Ready for the next focus session.");
+        }
+        return;
+      }
+      state = next;
+      renderPanel();
+    }, TICK_MS);
+  }
+};
+export {
+  plugin as default
+};

--- a/infra/community-repos/seed-plugins/pomodoro/manifest.json
+++ b/infra/community-repos/seed-plugins/pomodoro/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "pomodoro",
+  "name": "Pomodoro",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": {
+    "name": "Projelli Examples",
+    "githubUser": "projelli",
+    "url": "https://projelli.com"
+  },
+  "description": "A 25/5 pomodoro timer in the sidebar. Start, pause, and reset from toolbar buttons or the command palette. State persists across reloads.",
+  "main": "index.js",
+  "permissions": [],
+  "minProjelliVersion": "2.0.0",
+  "category": "productivity",
+  "tags": ["focus", "timer", "productivity"],
+  "screenshots": ["screenshots/preview.png"],
+  "homepage": "https://projelli.com/docs/plugins/examples.html",
+  "license": "MIT"
+}

--- a/infra/community-repos/seed-plugins/pomodoro/screenshots/README.md
+++ b/infra/community-repos/seed-plugins/pomodoro/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest currently references
+`screenshots/preview.png` as a placeholder. Real screenshots can replace it
+without manifest changes as long as the filename stays the same.

--- a/infra/community-repos/seed-plugins/translator/index.js
+++ b/infra/community-repos/seed-plugins/translator/index.js
@@ -1,0 +1,78 @@
+const SETTINGS_PAGE_ID = "translator-settings";
+const TARGET_LANGUAGE_KEY = "targetLanguage";
+const DEFAULT_TARGET_LANGUAGE = "Spanish";
+const SUPPORTED_LANGUAGES = [
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Portuguese",
+  "Dutch",
+  "Japanese",
+  "Korean",
+  "Mandarin Chinese",
+  "Arabic",
+  "Hindi",
+  "Russian",
+  "English"
+];
+async function getTargetLanguage(api) {
+  const stored = await api.settings.get(TARGET_LANGUAGE_KEY);
+  if (typeof stored === "string" && stored.trim().length > 0) return stored;
+  return DEFAULT_TARGET_LANGUAGE;
+}
+const plugin = {
+  async activate(api) {
+    api.settings.addPage({
+      id: SETTINGS_PAGE_ID,
+      title: "Translator",
+      schema: {
+        [TARGET_LANGUAGE_KEY]: {
+          type: "select",
+          default: DEFAULT_TARGET_LANGUAGE,
+          label: "Target language",
+          choices: SUPPORTED_LANGUAGES
+        }
+      }
+    });
+    api.commands.register("translator.translate", async () => {
+      const selection = await api.editor.getSelection();
+      if (!selection || !selection.text.trim()) {
+        api.notify.warn("Translator: select some text first.");
+        return null;
+      }
+      const targetLanguage = await getTargetLanguage(api);
+      api.notify.info(`Translating to ${targetLanguage}...`);
+      let translated;
+      try {
+        translated = await api.ai.invoke({
+          system: "You are a precise translator. Output only the translation. Preserve formatting, punctuation, and inline Markdown. Do not add commentary, quotation marks, or labels.",
+          prompt: `Translate the following text into ${targetLanguage}:
+
+${selection.text}`
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        api.notify.error(`Translator: AI request failed. ${message}`);
+        return null;
+      }
+      const cleaned = translated.trim();
+      if (!cleaned) {
+        api.notify.warn("Translator: empty response from AI provider.");
+        return null;
+      }
+      await api.editor.replaceSelection(cleaned);
+      api.notify.info(`Translated ${selection.text.length} chars to ${targetLanguage}.`);
+      return cleaned;
+    });
+    api.toolbar.addButton({
+      id: "translator-button",
+      icon: "languages",
+      tooltip: "Translate selection",
+      command: "translator.translate"
+    });
+  }
+};
+export {
+  plugin as default
+};

--- a/infra/community-repos/seed-plugins/translator/manifest.json
+++ b/infra/community-repos/seed-plugins/translator/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "translator",
+  "name": "Translator",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": {
+    "name": "Projelli Examples",
+    "githubUser": "projelli",
+    "url": "https://projelli.com"
+  },
+  "description": "Translate the selected text into a target language using your configured AI provider. Replaces the selection in place.",
+  "main": "index.js",
+  "permissions": ["editor:selection", "editor:write", "ai:invoke"],
+  "minProjelliVersion": "2.0.0",
+  "category": "writing",
+  "tags": ["editor", "ai", "translation", "i18n"],
+  "screenshots": ["screenshots/preview.png"],
+  "homepage": "https://projelli.com/docs/plugins/examples.html",
+  "license": "MIT"
+}

--- a/infra/community-repos/seed-plugins/translator/screenshots/README.md
+++ b/infra/community-repos/seed-plugins/translator/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest currently references
+`screenshots/preview.png` as a placeholder. Real screenshots can replace it
+without manifest changes as long as the filename stays the same.

--- a/infra/community-repos/seed-plugins/word-counter/index.js
+++ b/infra/community-repos/seed-plugins/word-counter/index.js
@@ -1,0 +1,65 @@
+const POLL_MS = 500;
+function computeStats(text) {
+  if (!text) return { words: 0, characters: 0, charactersNoSpaces: 0 };
+  const trimmed = text.trim();
+  const words = trimmed ? trimmed.split(/\s+/).length : 0;
+  const characters = text.length;
+  const charactersNoSpaces = text.replace(/\s+/g, "").length;
+  return { words, characters, charactersNoSpaces };
+}
+function renderPanelHtml(stats) {
+  return [
+    '<div style="font-family: system-ui, -apple-system, sans-serif; padding: 16px; color: #1f2937;">',
+    '<h2 style="margin: 0 0 12px; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">Word Counter</h2>',
+    '<div style="display: grid; gap: 10px;">',
+    `<div><div style="font-size: 28px; font-weight: 600; line-height: 1;">${stats.words.toLocaleString()}</div><div style="font-size: 12px; color: #6b7280; margin-top: 4px;">words</div></div>`,
+    `<div><div style="font-size: 18px; font-weight: 500;">${stats.characters.toLocaleString()}</div><div style="font-size: 12px; color: #6b7280; margin-top: 2px;">characters</div></div>`,
+    `<div><div style="font-size: 18px; font-weight: 500;">${stats.charactersNoSpaces.toLocaleString()}</div><div style="font-size: 12px; color: #6b7280; margin-top: 2px;">characters (no spaces)</div></div>`,
+    "</div>",
+    '<p style="margin: 16px 0 0; font-size: 11px; color: #9ca3af;">Updates every 500 ms.</p>',
+    "</div>"
+  ].join("");
+}
+const plugin = {
+  async activate(api) {
+    let lastSerialized = "";
+    const refresh = async () => {
+      let content = "";
+      try {
+        content = await api.editor.getContent();
+      } catch {
+      }
+      const stats = computeStats(content);
+      const serialized = `${stats.words}|${stats.characters}|${stats.charactersNoSpaces}`;
+      if (serialized !== lastSerialized) {
+        lastSerialized = serialized;
+        api.sidebar.addPanel({
+          id: "word-counter-panel",
+          title: "Word Counter",
+          html: renderPanelHtml(stats)
+        });
+      }
+      return stats;
+    };
+    api.commands.register("word-counter.count", async () => {
+      const stats = await refresh();
+      api.notify.info(
+        `${stats.words.toLocaleString()} words, ${stats.characters.toLocaleString()} characters`
+      );
+      return stats;
+    });
+    api.toolbar.addButton({
+      id: "word-counter-button",
+      icon: "hash",
+      tooltip: "Count words in the active document",
+      command: "word-counter.count"
+    });
+    await refresh();
+    setInterval(() => {
+      void refresh();
+    }, POLL_MS);
+  }
+};
+export {
+  plugin as default
+};

--- a/infra/community-repos/seed-plugins/word-counter/manifest.json
+++ b/infra/community-repos/seed-plugins/word-counter/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "word-counter",
+  "name": "Word Counter",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": {
+    "name": "Projelli Examples",
+    "githubUser": "projelli",
+    "url": "https://projelli.com"
+  },
+  "description": "Live word and character count for the active document. Updates a sidebar panel automatically.",
+  "main": "index.js",
+  "permissions": ["editor:selection"],
+  "minProjelliVersion": "2.0.0",
+  "category": "writing",
+  "tags": ["editor", "writing", "stats"],
+  "screenshots": ["screenshots/preview.png"],
+  "homepage": "https://projelli.com/docs/plugins/examples.html",
+  "license": "MIT"
+}

--- a/infra/community-repos/seed-plugins/word-counter/screenshots/README.md
+++ b/infra/community-repos/seed-plugins/word-counter/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest currently references
+`screenshots/preview.png` as a placeholder. Real screenshots can replace it
+without manifest changes as long as the filename stays the same.

--- a/infra/community-repos/seed-templates/beta-user-survey/manifest.json
+++ b/infra/community-repos/seed-templates/beta-user-survey/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "beta-user-survey",
+  "name": "Beta User Survey",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Short survey for beta users. PMF question (Sean Ellis), NPS, key activation question, and one open-ended request. Designed to take under 3 minutes.",
+  "category": "research",
+  "tags": ["survey", "pmf", "beta", "feedback"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/beta-user-survey/questions.json
+++ b/infra/community-repos/seed-templates/beta-user-survey/questions.json
@@ -1,0 +1,8 @@
+{
+  "questions": [
+    { "id": "productName", "question": "Product name", "type": "text", "required": true },
+    { "id": "targetAudience", "question": "Who is the target audience? (Used in the NPS question)", "type": "text", "required": true, "placeholder": "other indie founders" },
+    { "id": "deliveryChannel", "question": "How will you send this? (Tally, Typeform, Google Forms, email, etc.)", "type": "text", "required": false, "placeholder": "Tally" },
+    { "id": "primaryGoal", "question": "What's the primary thing you want to learn from this round?", "type": "textarea", "required": true }
+  ]
+}

--- a/infra/community-repos/seed-templates/beta-user-survey/screenshots/README.md
+++ b/infra/community-repos/seed-templates/beta-user-survey/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/beta-user-survey/template.md
+++ b/infra/community-repos/seed-templates/beta-user-survey/template.md
@@ -1,0 +1,39 @@
+# {{productName}} Beta Survey
+
+Hi! Thanks for trying {{productName}}. This will take under 3 minutes and tells us whether to keep building.
+
+## 1. Product-Market Fit (Sean Ellis)
+How would you feel if you could no longer use {{productName}}?
+- [ ] Very disappointed
+- [ ] Somewhat disappointed
+- [ ] Not disappointed
+- [ ] I haven't really used it
+
+## 2. Activation
+What's the main thing you've used {{productName}} for so far?
+
+[Open-ended]
+
+## 3. NPS
+On a scale of 0 to 10, how likely are you to recommend {{productName}} to {{targetAudience}}?
+
+[0 to 10]
+
+## 4. Why?
+Tell us why you gave that score.
+
+[Open-ended]
+
+## 5. The One Thing
+If we could only fix one thing this month, what would have the biggest impact for you?
+
+[Open-ended]
+
+## 6. (Optional) Can we follow up?
+If you'd be open to a 15-minute call, drop your email here.
+
+[Email]
+
+---
+
+Thank you. Every answer goes straight to the founder.

--- a/infra/community-repos/seed-templates/beta-user-survey/workflow.json
+++ b/infra/community-repos/seed-templates/beta-user-survey/workflow.json
@@ -1,0 +1,34 @@
+{
+  "id": "beta-user-survey",
+  "name": "Beta User Survey",
+  "description": "Generate a 6-question survey to send to beta users.",
+  "version": "1.0.0",
+  "category": "research",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Survey Setup",
+      "config": {
+        "questions": [
+          { "id": "productName", "question": "Product name", "type": "text", "required": true },
+          { "id": "targetAudience", "question": "Who is the target audience? (Used in the NPS question)", "type": "text", "required": true, "placeholder": "other indie founders" },
+          { "id": "deliveryChannel", "question": "How will you send this? (Tally, Typeform, Google Forms, email, etc.)", "type": "text", "required": false, "placeholder": "Tally" },
+          { "id": "primaryGoal", "question": "What's the primary thing you want to learn from this round?", "type": "textarea", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "generate",
+      "type": "generate",
+      "name": "Generate Survey",
+      "config": {
+        "outputFile": "BETA_SURVEY.md",
+        "promptTemplate": "Write a 6-question beta-user survey for {{productName}}. Keep it under 3 minutes to complete. Include the Sean Ellis PMF question, an open-ended activation question, an NPS question targeting {{targetAudience}}, an NPS-explanation follow-up, a 'one thing to fix' question, and an optional follow-up email field. Phrase questions in plain second-person language. Goal of this round: {{primaryGoal}}. Delivery channel: {{deliveryChannel}}. Add a one-sentence intro and a one-sentence thank-you.",
+        "systemPrompt": "Survey design rule: short and ruthless. Every question earns its place."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["BETA_SURVEY.md"]
+}

--- a/infra/community-repos/seed-templates/cold-email-sequence/manifest.json
+++ b/infra/community-repos/seed-templates/cold-email-sequence/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "cold-email-sequence",
+  "name": "Cold Email Sequence",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Five-email outbound sequence for B2B outreach. Hook, value, social proof, soft ask, breakup. Plain text. No fluff.",
+  "category": "marketing",
+  "tags": ["sales", "outbound", "email", "cold-email"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/cold-email-sequence/questions.json
+++ b/infra/community-repos/seed-templates/cold-email-sequence/questions.json
@@ -1,0 +1,11 @@
+{
+  "questions": [
+    { "id": "campaignName", "question": "Campaign name", "type": "text", "required": true },
+    { "id": "senderName", "question": "Sender name", "type": "text", "required": true },
+    { "id": "senderRole", "question": "Sender role and company", "type": "text", "required": true },
+    { "id": "audience", "question": "Who are you emailing? Be specific (role, company size, industry).", "type": "textarea", "required": true },
+    { "id": "problemArea", "question": "What problem do they have that you solve?", "type": "text", "required": true },
+    { "id": "offer", "question": "What's your offer or angle? (Free audit, demo, content, etc.)", "type": "textarea", "required": true },
+    { "id": "outcome", "question": "What outcome did past customers get?", "type": "text", "required": true, "placeholder": "20% reduction in onboarding time" }
+  ]
+}

--- a/infra/community-repos/seed-templates/cold-email-sequence/screenshots/README.md
+++ b/infra/community-repos/seed-templates/cold-email-sequence/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/cold-email-sequence/template.md
+++ b/infra/community-repos/seed-templates/cold-email-sequence/template.md
@@ -1,0 +1,63 @@
+# Cold Email Sequence: {{campaignName}}
+
+## Sender
+{{senderName}} ({{senderRole}})
+
+## Audience
+{{audience}}
+
+## Offer
+{{offer}}
+
+## Email 1: Hook (Day 0)
+**Subject:** {{subject1}}
+
+Hi {{firstName}},
+
+[One-sentence personal observation that proves I've done research.]
+
+[One-sentence reason that observation matters to them.]
+
+Worth a quick reply?
+
+{{senderName}}
+
+## Email 2: Value (Day 3)
+**Subject:** Re: {{subject1}}
+
+Hi {{firstName}},
+
+Sharing one thing in case it's useful: [specific tactic, number, or resource].
+
+If it lands, I'd love to hear what you're already doing on this.
+
+{{senderName}}
+
+## Email 3: Social Proof (Day 7)
+**Subject:** {{subject3}}
+
+Hi {{firstName}},
+
+Two folks at companies like yours shipped {{outcome}} after we worked together: [Name, Company] and [Name, Company]. Happy to share what they did.
+
+15 minutes next week?
+
+{{senderName}}
+
+## Email 4: Soft Ask (Day 12)
+**Subject:** Quick question
+
+Hi {{firstName}},
+
+Are you the right person at {{company}} to talk to about {{problemArea}}? If not, no worries. Could you point me to who is?
+
+{{senderName}}
+
+## Email 5: Breakup (Day 18)
+**Subject:** Closing the loop
+
+Hi {{firstName}},
+
+Haven't heard back so I'll close the loop. If timing isn't right, totally understand. I'll stop by again in a few months.
+
+{{senderName}}

--- a/infra/community-repos/seed-templates/cold-email-sequence/workflow.json
+++ b/infra/community-repos/seed-templates/cold-email-sequence/workflow.json
@@ -1,0 +1,39 @@
+{
+  "id": "cold-email-sequence",
+  "name": "Cold Email Sequence",
+  "description": "Generate a 5-email outbound sequence personalized to your audience and offer.",
+  "version": "1.0.0",
+  "category": "planning",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Campaign Setup",
+      "description": "Tell me about the campaign.",
+      "config": {
+        "questions": [
+          { "id": "campaignName", "question": "Campaign name", "type": "text", "required": true },
+          { "id": "senderName", "question": "Sender name", "type": "text", "required": true },
+          { "id": "senderRole", "question": "Sender role and company", "type": "text", "required": true },
+          { "id": "audience", "question": "Who are you emailing? Be specific (role, company size, industry).", "type": "textarea", "required": true },
+          { "id": "problemArea", "question": "What problem do they have that you solve?", "type": "text", "required": true },
+          { "id": "offer", "question": "What's your offer or angle? (Free audit, demo, content, etc.)", "type": "textarea", "required": true },
+          { "id": "outcome", "question": "What outcome did past customers get?", "type": "text", "required": true, "placeholder": "20% reduction in onboarding time" }
+        ]
+      }
+    },
+    {
+      "id": "generate",
+      "type": "generate",
+      "name": "Generate 5-Email Sequence",
+      "description": "Write the sequence in plain text.",
+      "config": {
+        "outputFile": "COLD_EMAIL_SEQUENCE.md",
+        "promptTemplate": "Write a 5-email cold outbound sequence for the following campaign. Plain text only. No marketing-speak. Each email under 80 words. Sender: {{senderName}}, {{senderRole}}. Audience: {{audience}}. Problem: {{problemArea}}. Offer: {{offer}}. Past outcome: {{outcome}}. Use the structure: Email 1 Hook (specific personal observation), Email 2 Value (one tactic or insight), Email 3 Social Proof (two named outcomes), Email 4 Soft Ask (right-person check), Email 5 Breakup (close the loop politely). Include subject lines for each. No exclamation marks. No 'just checking in'. No 'circling back'.",
+        "systemPrompt": "Write like a real person. Short sentences. No corporate filler."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["COLD_EMAIL_SEQUENCE.md"]
+}

--- a/infra/community-repos/seed-templates/customer-discovery-interview/manifest.json
+++ b/infra/community-repos/seed-templates/customer-discovery-interview/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "customer-discovery-interview",
+  "name": "Customer Discovery Interview (Community)",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Run a non-leading discovery interview using The Mom Test rules. Produces a script, a recruiting message, and a notes template.",
+  "category": "research",
+  "tags": ["interview", "discovery", "validation", "mom-test"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/customer-discovery-interview/questions.json
+++ b/infra/community-repos/seed-templates/customer-discovery-interview/questions.json
@@ -1,0 +1,9 @@
+{
+  "questions": [
+    { "id": "interviewGoal", "question": "What's the main thing you want to learn?", "type": "select", "required": true, "options": ["Whether the problem is real", "Whether they would use a solution", "Whether they would pay", "What feature matters most", "General discovery"] },
+    { "id": "targetCustomer", "question": "Who are you interviewing?", "type": "textarea", "required": true, "placeholder": "Freelance designers who invoice 3+ clients/month" },
+    { "id": "problemArea", "question": "What problem area are you exploring?", "type": "text", "required": true, "placeholder": "Time tracking and invoicing" },
+    { "id": "relevantTask", "question": "What's the specific task you want them to walk you through?", "type": "text", "required": true, "placeholder": "sent your last invoice" },
+    { "id": "assumptions", "question": "What assumptions do you want to test?", "type": "textarea", "required": true }
+  ]
+}

--- a/infra/community-repos/seed-templates/customer-discovery-interview/screenshots/README.md
+++ b/infra/community-repos/seed-templates/customer-discovery-interview/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/customer-discovery-interview/template.md
+++ b/infra/community-repos/seed-templates/customer-discovery-interview/template.md
@@ -1,0 +1,42 @@
+# Customer Discovery Interview
+
+## Goal
+{{interviewGoal}}
+
+## Who I'm Talking To
+{{targetCustomer}}
+
+## Assumptions I'm Trying To Test
+{{assumptions}}
+
+## Opening (2 minutes)
+Thanks for taking the time. I'm trying to understand how you handle {{problemArea}}. I'm not selling anything. Just learning. Mind if I record so I can pay attention instead of typing?
+
+## Past Behavior (10 to 15 minutes)
+- Walk me through the last time you {{relevantTask}}.
+- What made you do it that way?
+- What was the hardest part?
+- What did you do right after?
+- How often does this come up?
+
+## Workarounds (5 minutes)
+- What do you use today to handle {{problemArea}}?
+- What do you like about it?
+- What would have to break for you to switch?
+
+## Cost (5 minutes)
+- What does {{problemArea}} cost you in time, money, or stress?
+- Have you ever paid for a tool to help with it?
+- If you had a magic wand, what would it do?
+
+## Closing (3 minutes)
+- Anything I should have asked?
+- Who else should I talk to?
+- Can I follow up once I have something to show you?
+
+## Notes Template
+- Quotes that surprised me:
+- Pain rating (1 to 10):
+- Current workaround:
+- Whether they would pay:
+- Follow-up needed:

--- a/infra/community-repos/seed-templates/customer-discovery-interview/workflow.json
+++ b/infra/community-repos/seed-templates/customer-discovery-interview/workflow.json
@@ -1,0 +1,47 @@
+{
+  "id": "customer-discovery-interview",
+  "name": "Customer Discovery Interview (Community)",
+  "description": "Generate a non-leading interview script and notes template based on The Mom Test.",
+  "version": "1.0.0",
+  "category": "research",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Interview Setup",
+      "description": "Tell me what you're trying to learn.",
+      "config": {
+        "questions": [
+          { "id": "interviewGoal", "question": "What's the main thing you want to learn?", "type": "select", "required": true, "options": ["Whether the problem is real", "Whether they would use a solution", "Whether they would pay", "What feature matters most", "General discovery"] },
+          { "id": "targetCustomer", "question": "Who are you interviewing?", "type": "textarea", "required": true, "placeholder": "Freelance designers who invoice 3+ clients/month" },
+          { "id": "problemArea", "question": "What problem area are you exploring?", "type": "text", "required": true, "placeholder": "Time tracking and invoicing" },
+          { "id": "relevantTask", "question": "What's the specific task you want them to walk you through?", "type": "text", "required": true, "placeholder": "sent your last invoice" },
+          { "id": "assumptions", "question": "What assumptions do you want to test?", "type": "textarea", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "generate-script",
+      "type": "generate",
+      "name": "Generate Interview Script",
+      "description": "Write the script and notes template.",
+      "config": {
+        "outputFile": "INTERVIEW_SCRIPT.md",
+        "promptTemplate": "You are a customer-research expert trained in The Mom Test. Generate a complete interview script for the following founder. Goal: {{interviewGoal}}. Target: {{targetCustomer}}. Problem: {{problemArea}}. Walk-through task: {{relevantTask}}. Assumptions to test: {{assumptions}}. Output sections: Goal, Audience, Opening, Past Behavior, Workarounds, Cost, Closing, Notes Template. Rules: never ask hypothetical or leading questions. Always anchor to past behavior. No selling.",
+        "systemPrompt": "Apply The Mom Test rigorously. Past behavior beats opinion. Never sell."
+      }
+    },
+    {
+      "id": "generate-recruiting",
+      "type": "generate",
+      "name": "Recruiting Message",
+      "description": "Short outreach message to find interviewees.",
+      "config": {
+        "outputFile": "RECRUITING.md",
+        "promptTemplate": "Write a friendly 4-sentence outreach message asking {{targetCustomer}} for a 20-minute call about {{problemArea}}. No pitch. Offer to share findings. Sign as 'the founder'."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["INTERVIEW_SCRIPT.md", "RECRUITING.md"]
+}

--- a/infra/community-repos/seed-templates/investor-update-email-community/manifest.json
+++ b/infra/community-repos/seed-templates/investor-update-email-community/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "investor-update-email-community",
+  "name": "Investor Update Email (Community)",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Monthly investor update in the TLDR + metrics + asks format. Lighter than the built-in version. Designed for small angel rounds and pre-seed.",
+  "category": "planning",
+  "tags": ["investor", "fundraising", "email", "monthly-update"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/investor-update-email-community/questions.json
+++ b/infra/community-repos/seed-templates/investor-update-email-community/questions.json
@@ -1,0 +1,16 @@
+{
+  "questions": [
+    { "id": "companyName", "question": "Company name", "type": "text", "required": true },
+    { "id": "monthYear", "question": "Month and year (e.g. May 2026)", "type": "text", "required": true },
+    { "id": "senderName", "question": "Your name", "type": "text", "required": true },
+    { "id": "mrr", "question": "MRR (or 'pre-revenue')", "type": "text", "required": true },
+    { "id": "customerCount", "question": "Customer or active-user count", "type": "text", "required": true },
+    { "id": "cashOnHand", "question": "Cash on hand", "type": "text", "required": true },
+    { "id": "runwayMonths", "question": "Months of runway", "type": "text", "required": true },
+    { "id": "shipped", "question": "What did you ship this month? (3 bullets)", "type": "textarea", "required": true },
+    { "id": "learnings", "question": "What did you learn? (2 to 3 sentences. Honest beats optimistic.)", "type": "textarea", "required": true },
+    { "id": "nextMonth", "question": "What's next month's focus? (3 bullets)", "type": "textarea", "required": true },
+    { "id": "asks", "question": "Two specific asks (intros, hires, advice)", "type": "textarea", "required": true },
+    { "id": "shoutouts", "question": "Any wins or shoutouts? (Optional)", "type": "textarea", "required": false }
+  ]
+}

--- a/infra/community-repos/seed-templates/investor-update-email-community/screenshots/README.md
+++ b/infra/community-repos/seed-templates/investor-update-email-community/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/investor-update-email-community/template.md
+++ b/infra/community-repos/seed-templates/investor-update-email-community/template.md
@@ -1,0 +1,33 @@
+# {{companyName}} Update: {{monthYear}}
+
+## TLDR
+{{tldr}}
+
+## Metrics
+- Revenue (MRR): {{mrr}}
+- Customers: {{customerCount}}
+- Cash on hand: {{cashOnHand}}
+- Months of runway: {{runwayMonths}}
+
+## What we shipped
+- {{shippedItem1}}
+- {{shippedItem2}}
+- {{shippedItem3}}
+
+## What we learned
+{{learnings}}
+
+## What's next
+- {{nextItem1}}
+- {{nextItem2}}
+- {{nextItem3}}
+
+## Asks
+1. {{ask1}}
+2. {{ask2}}
+
+## Wins and shoutouts
+{{shoutouts}}
+
+Thanks,
+{{senderName}}

--- a/infra/community-repos/seed-templates/investor-update-email-community/workflow.json
+++ b/infra/community-repos/seed-templates/investor-update-email-community/workflow.json
@@ -1,0 +1,42 @@
+{
+  "id": "investor-update-email-community",
+  "name": "Investor Update Email (Community)",
+  "description": "Generate a short monthly investor update with metrics, learnings, and asks.",
+  "version": "1.0.0",
+  "category": "planning",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Update Setup",
+      "config": {
+        "questions": [
+          { "id": "companyName", "question": "Company name", "type": "text", "required": true },
+          { "id": "monthYear", "question": "Month and year (e.g. May 2026)", "type": "text", "required": true },
+          { "id": "senderName", "question": "Your name", "type": "text", "required": true },
+          { "id": "mrr", "question": "MRR (or 'pre-revenue')", "type": "text", "required": true },
+          { "id": "customerCount", "question": "Customer or active-user count", "type": "text", "required": true },
+          { "id": "cashOnHand", "question": "Cash on hand", "type": "text", "required": true },
+          { "id": "runwayMonths", "question": "Months of runway", "type": "text", "required": true },
+          { "id": "shipped", "question": "What did you ship this month? (3 bullets)", "type": "textarea", "required": true },
+          { "id": "learnings", "question": "What did you learn? (2 to 3 sentences. Honest beats optimistic.)", "type": "textarea", "required": true },
+          { "id": "nextMonth", "question": "What's next month's focus? (3 bullets)", "type": "textarea", "required": true },
+          { "id": "asks", "question": "Two specific asks (intros, hires, advice)", "type": "textarea", "required": true },
+          { "id": "shoutouts", "question": "Any wins or shoutouts? (Optional)", "type": "textarea", "required": false }
+        ]
+      }
+    },
+    {
+      "id": "generate",
+      "type": "generate",
+      "name": "Generate Update",
+      "config": {
+        "outputFile": "INVESTOR_UPDATE.md",
+        "promptTemplate": "Write a monthly investor update for {{companyName}} ({{monthYear}}). Use the TLDR + metrics + shipped + learned + next + asks structure. Sender: {{senderName}}. MRR: {{mrr}}. Customers: {{customerCount}}. Cash: {{cashOnHand}}. Runway: {{runwayMonths}} months. Shipped: {{shipped}}. Learned: {{learnings}}. Next: {{nextMonth}}. Asks: {{asks}}. Shoutouts: {{shoutouts}}. Tone: candid, plain, founder voice. Lead with the TLDR sentence that summarizes the whole update. Investors should be able to skim in 30 seconds. Don't sugar-coat misses. End with two specific asks and a thank you.",
+        "systemPrompt": "Investor updates work when they're honest. Highlight one miss alongside wins."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["INVESTOR_UPDATE.md"]
+}

--- a/infra/community-repos/seed-templates/launch-announcement-tweet-thread/manifest.json
+++ b/infra/community-repos/seed-templates/launch-announcement-tweet-thread/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "launch-announcement-tweet-thread",
+  "name": "Launch Announcement Tweet Thread",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Eight-tweet launch thread. Hook, problem, demo moment, three feature tweets, social proof, call to action. Each tweet under 280 chars.",
+  "category": "marketing",
+  "tags": ["launch", "twitter", "x", "thread", "marketing"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/launch-announcement-tweet-thread/questions.json
+++ b/infra/community-repos/seed-templates/launch-announcement-tweet-thread/questions.json
@@ -1,0 +1,11 @@
+{
+  "questions": [
+    { "id": "productName", "question": "Product name", "type": "text", "required": true },
+    { "id": "oneLiner", "question": "One-line product pitch", "type": "text", "required": true, "placeholder": "Local-first AI workspace for indie founders" },
+    { "id": "targetAudience", "question": "Who's it for?", "type": "text", "required": true },
+    { "id": "problem", "question": "What problem does it solve? (One sentence.)", "type": "text", "required": true },
+    { "id": "topFeatures", "question": "Top 3 features or moments", "type": "textarea", "required": true },
+    { "id": "socialProof", "question": "Any quotes, numbers, or names you can drop? (Optional)", "type": "textarea", "required": false },
+    { "id": "landingUrl", "question": "Landing page URL", "type": "text", "required": true }
+  ]
+}

--- a/infra/community-repos/seed-templates/launch-announcement-tweet-thread/screenshots/README.md
+++ b/infra/community-repos/seed-templates/launch-announcement-tweet-thread/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/launch-announcement-tweet-thread/template.md
+++ b/infra/community-repos/seed-templates/launch-announcement-tweet-thread/template.md
@@ -1,0 +1,38 @@
+# {{productName}} Launch Thread
+
+## Tweet 1 (Hook)
+{{hook}}
+
+[Attach: hero screenshot or short video]
+
+## Tweet 2 (Problem)
+{{problemStatement}}
+
+## Tweet 3 (Demo Moment)
+{{demoMoment}}
+
+[Attach: 5-15 second clip]
+
+## Tweet 4 (Feature 1)
+{{feature1}}
+
+## Tweet 5 (Feature 2)
+{{feature2}}
+
+## Tweet 6 (Feature 3)
+{{feature3}}
+
+## Tweet 7 (Social Proof)
+{{socialProof}}
+
+## Tweet 8 (Call To Action)
+{{cta}}
+
+[Link to {{landingUrl}}]
+
+---
+
+## Notes
+- Post window: weekday 9am to 11am or 1pm to 3pm in your audience's timezone
+- Reply to your own thread once an hour for the first 4 hours
+- DM 5 friends asking for a like or repost (do this BEFORE you publish)

--- a/infra/community-repos/seed-templates/launch-announcement-tweet-thread/workflow.json
+++ b/infra/community-repos/seed-templates/launch-announcement-tweet-thread/workflow.json
@@ -1,0 +1,37 @@
+{
+  "id": "launch-announcement-tweet-thread",
+  "name": "Launch Announcement Tweet Thread",
+  "description": "Generate an 8-tweet launch thread plus posting notes.",
+  "version": "1.0.0",
+  "category": "planning",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Launch Setup",
+      "config": {
+        "questions": [
+          { "id": "productName", "question": "Product name", "type": "text", "required": true },
+          { "id": "oneLiner", "question": "One-line product pitch", "type": "text", "required": true, "placeholder": "Local-first AI workspace for indie founders" },
+          { "id": "targetAudience", "question": "Who's it for?", "type": "text", "required": true },
+          { "id": "problem", "question": "What problem does it solve? (One sentence.)", "type": "text", "required": true },
+          { "id": "topFeatures", "question": "Top 3 features or moments", "type": "textarea", "required": true },
+          { "id": "socialProof", "question": "Any quotes, numbers, or names you can drop? (Optional)", "type": "textarea", "required": false },
+          { "id": "landingUrl", "question": "Landing page URL", "type": "text", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "generate",
+      "type": "generate",
+      "name": "Generate Thread",
+      "config": {
+        "outputFile": "LAUNCH_THREAD.md",
+        "promptTemplate": "Write an 8-tweet launch thread for {{productName}} ({{oneLiner}}). Audience: {{targetAudience}}. Problem: {{problem}}. Features: {{topFeatures}}. Social proof: {{socialProof}}. CTA URL: {{landingUrl}}. Structure: (1) Hook in under 240 chars that names the product and the unfair advantage, (2) Problem in one painful sentence, (3) Demo moment that names a single before/after action, (4-6) one feature per tweet phrased as a benefit, (7) Social proof with names if available else a credible number, (8) CTA with link. Every tweet must stand alone if quoted. No emoji storms. No 'Excited to announce'. No 'a thread'. End with posting notes (best window, reply cadence, ask 5 friends pattern).",
+        "systemPrompt": "Write punchy. Specific verbs. No exclamation marks unless one truly earns it."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["LAUNCH_THREAD.md"]
+}

--- a/infra/community-repos/seed-templates/press-release/manifest.json
+++ b/infra/community-repos/seed-templates/press-release/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "press-release",
+  "name": "Press Release",
+  "version": "1.0.0",
+  "apiVersion": "1.0",
+  "author": {
+    "name": "Projelli Team",
+    "githubUser": "projelli"
+  },
+  "description": "Standard press-release format with headline, dateline, lede, supporting paragraphs, two quotes, and a boilerplate. Inverted-pyramid structure.",
+  "category": "marketing",
+  "tags": ["press", "pr", "launch", "announcement"],
+  "screenshots": ["screenshots/preview.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}

--- a/infra/community-repos/seed-templates/press-release/questions.json
+++ b/infra/community-repos/seed-templates/press-release/questions.json
@@ -1,0 +1,14 @@
+{
+  "questions": [
+    { "id": "companyName", "question": "Company name", "type": "text", "required": true },
+    { "id": "companyDescription", "question": "One-line company description (what you do, who for)", "type": "text", "required": true },
+    { "id": "announcement", "question": "What are you announcing?", "type": "textarea", "required": true },
+    { "id": "whyNow", "question": "Why now? Why does this matter today?", "type": "textarea", "required": true },
+    { "id": "supportingFacts", "question": "Two or three supporting facts, numbers, or partner names", "type": "textarea", "required": true },
+    { "id": "quote1Speaker", "question": "First quote speaker (name and title)", "type": "text", "required": true },
+    { "id": "quote2Speaker", "question": "Second quote speaker, ideally a customer or partner", "type": "text", "required": false },
+    { "id": "callToAction", "question": "What should readers do? (Sign up, download, contact, etc.)", "type": "text", "required": true },
+    { "id": "boilerplate", "question": "Two-sentence company boilerplate", "type": "textarea", "required": true },
+    { "id": "mediaContact", "question": "Media contact (name, email, phone)", "type": "textarea", "required": true }
+  ]
+}

--- a/infra/community-repos/seed-templates/press-release/screenshots/README.md
+++ b/infra/community-repos/seed-templates/press-release/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Drop one or more PNGs in this folder. The manifest references
+`screenshots/preview.png` as a placeholder. Replace it with a real screenshot
+without changing the manifest.

--- a/infra/community-repos/seed-templates/press-release/template.md
+++ b/infra/community-repos/seed-templates/press-release/template.md
@@ -1,0 +1,28 @@
+FOR IMMEDIATE RELEASE
+
+# {{headline}}
+
+**{{subhead}}**
+
+{{cityState}} ({{releaseDate}}) {{companyName}}, {{companyDescription}}, today announced {{announcementSummary}}.
+
+{{paragraph2}}
+
+"{{quote1}}" said {{quote1Speaker}}, {{quote1Title}} at {{companyName}}. "{{quote1Continued}}"
+
+{{supportingParagraph}}
+
+"{{quote2}}" said {{quote2Speaker}}, {{quote2Title}}. "{{quote2Continued}}"
+
+{{callToAction}}
+
+## About {{companyName}}
+{{boilerplate}}
+
+## Media Contact
+{{mediaContactName}}
+{{mediaContactRole}}
+{{mediaContactEmail}}
+{{mediaContactPhone}}
+
+###

--- a/infra/community-repos/seed-templates/press-release/workflow.json
+++ b/infra/community-repos/seed-templates/press-release/workflow.json
@@ -1,0 +1,42 @@
+{
+  "id": "press-release",
+  "name": "Press Release",
+  "description": "Generate a wire-service-ready press release in inverted-pyramid format.",
+  "version": "1.0.0",
+  "category": "planning",
+  "steps": [
+    {
+      "id": "interview",
+      "type": "interview",
+      "name": "Release Setup",
+      "description": "Collect the facts.",
+      "config": {
+        "questions": [
+          { "id": "companyName", "question": "Company name", "type": "text", "required": true },
+          { "id": "companyDescription", "question": "One-line company description (what you do, who for)", "type": "text", "required": true },
+          { "id": "announcement", "question": "What are you announcing?", "type": "textarea", "required": true },
+          { "id": "whyNow", "question": "Why now? Why does this matter today?", "type": "textarea", "required": true },
+          { "id": "supportingFacts", "question": "Two or three supporting facts, numbers, or partner names", "type": "textarea", "required": true },
+          { "id": "quote1Speaker", "question": "First quote speaker (name and title)", "type": "text", "required": true },
+          { "id": "quote2Speaker", "question": "Second quote speaker, ideally a customer or partner", "type": "text", "required": false },
+          { "id": "callToAction", "question": "What should readers do? (Sign up, download, contact, etc.)", "type": "text", "required": true },
+          { "id": "boilerplate", "question": "Two-sentence company boilerplate", "type": "textarea", "required": true },
+          { "id": "mediaContact", "question": "Media contact (name, email, phone)", "type": "textarea", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "generate",
+      "type": "generate",
+      "name": "Generate Press Release",
+      "description": "Write the release.",
+      "config": {
+        "outputFile": "PRESS_RELEASE.md",
+        "promptTemplate": "Write a wire-service-ready press release. Inverted pyramid: most important fact first. Format: dateline, lede paragraph (who/what/when/where/why), one supporting paragraph, one quote from {{quote1Speaker}}, one supporting paragraph, one quote from {{quote2Speaker}} (skip if blank), call to action, About boilerplate, media contact. Company: {{companyName}} ({{companyDescription}}). Announcement: {{announcement}}. Why now: {{whyNow}}. Supporting facts: {{supportingFacts}}. CTA: {{callToAction}}. Boilerplate: {{boilerplate}}. Contact: {{mediaContact}}. Tone: factual, declarative, no marketing-speak. No exclamation marks. No words like 'revolutionary', 'transform', 'leverage'.",
+        "systemPrompt": "Write like AP wire copy. Facts first. No fluff."
+      }
+    }
+  ],
+  "requiredInputs": [],
+  "outputs": ["PRESS_RELEASE.md"]
+}

--- a/infra/community-repos/sync-to-github.sh
+++ b/infra/community-repos/sync-to-github.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# infra/community-repos/sync-to-github.sh
+#
+# One-shot, idempotent sync from this projelli/projelli repo's source-of-truth
+# files in infra/community-repos/ to the two live community GitHub repos:
+#
+#   - projelli/community-templates  (catalog of community template entries)
+#   - projelli/community-plugins    (catalog of community plugin entries)
+#
+# What it does, per kind:
+#   1. Creates the repo via `gh repo create` if it doesn't exist (idempotent;
+#      if create fails because the repo already exists, treat as success and
+#      proceed).
+#   2. Clones the repo into /tmp/community-repos-sync/<name> (or pulls if a
+#      previous run already cloned).
+#   3. Replaces:
+#        README.md
+#        scripts/build-catalog.mjs
+#        scripts/package.json   (declares zod dep so the Action can install it)
+#        .github/workflows/build-catalog.yml
+#        entries/                (full mirror from seed-templates / seed-plugins)
+#        catalog.json            (initial empty array on first push so the
+#                                 Action's first run produces a no-op diff)
+#   4. Commits + pushes. The very first commit includes "[skip ci]" in the
+#      message; this prevents the GitHub Action from running on the initial
+#      seed push (we already include an empty catalog.json so the marketplace
+#      can fetch a valid response immediately). Subsequent runs skip [skip ci]
+#      so changes do trigger a rebuild.
+#
+# Why "[skip ci] on the first push"?
+#   The Action commits the rebuilt catalog.json + tarballs back to main with
+#   its own [skip ci] tag. If we let the Action run on the seed-import push,
+#   the bot's commit lands on top of our seed history, which is fine but
+#   noisy. Skipping CI on the seed push means a single human-readable initial
+#   commit that already carries everything the marketplace needs to load.
+#   The next seed/entry push (any) re-triggers the Action normally.
+#
+# Run from repo root:
+#   ./infra/community-repos/sync-to-github.sh
+#
+# Optional env:
+#   PROJELLI_SYNC_KIND=templates  Sync only that one kind. Defaults to both.
+#   PROJELLI_SYNC_DRYRUN=1        Skip push step (still commits locally).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC_DIR="${REPO_ROOT}/infra/community-repos"
+WORK_DIR="/tmp/community-repos-sync"
+GH_OWNER="projelli"
+
+KINDS_TO_SYNC=("${PROJELLI_SYNC_KIND:-both}")
+if [[ "${KINDS_TO_SYNC[0]}" == "both" ]]; then
+  KINDS_TO_SYNC=("templates" "plugins")
+fi
+
+DRYRUN="${PROJELLI_SYNC_DRYRUN:-0}"
+
+mkdir -p "${WORK_DIR}"
+
+log() { printf '\n[sync] %s\n' "$*"; }
+
+# Check gh auth before doing anything destructive.
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+# Verify source-of-truth files all exist before we touch the network.
+required_files=(
+  "${SRC_DIR}/build-catalog.mjs"
+  "${SRC_DIR}/build-catalog.yml"
+  "${SRC_DIR}/templates-readme.md"
+  "${SRC_DIR}/plugins-readme.md"
+)
+for f in "${required_files[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: required source-of-truth file missing: $f" >&2
+    exit 1
+  fi
+done
+
+sync_one_kind() {
+  local kind="$1"  # "templates" or "plugins"
+
+  local repo_name readme_src seeds_src description
+  case "$kind" in
+    templates)
+      repo_name="community-templates"
+      readme_src="${SRC_DIR}/templates-readme.md"
+      seeds_src="${SRC_DIR}/seed-templates"
+      description="Community-contributed templates for Projelli. See README for submission process."
+      ;;
+    plugins)
+      repo_name="community-plugins"
+      readme_src="${SRC_DIR}/plugins-readme.md"
+      seeds_src="${SRC_DIR}/seed-plugins"
+      description="Community-contributed plugins for Projelli. See README for submission process."
+      ;;
+    *)
+      echo "ERROR: unknown kind '$kind' (expected templates|plugins)" >&2
+      return 1
+      ;;
+  esac
+
+  local full_repo="${GH_OWNER}/${repo_name}"
+  local clone_dir="${WORK_DIR}/${repo_name}"
+
+  log "=== syncing ${full_repo} ==="
+
+  # Step 1: ensure repo exists. `gh repo view` returns non-zero if missing.
+  if gh repo view "${full_repo}" >/dev/null 2>&1; then
+    log "repo ${full_repo} already exists"
+  else
+    log "creating ${full_repo}"
+    # `gh repo create` will print the URL on success. If it fails for any
+    # reason other than "name already exists" (e.g. permissions), let the
+    # caller see the stderr and abort.
+    if ! gh repo create "${full_repo}" --public --description "${description}"; then
+      # Race / concurrent run: re-check existence and continue if found.
+      if gh repo view "${full_repo}" >/dev/null 2>&1; then
+        log "repo appeared during creation, continuing"
+      else
+        echo "ERROR: failed to create ${full_repo}" >&2
+        return 1
+      fi
+    fi
+  fi
+
+  # Step 2: clone or refresh the local mirror.
+  if [[ -d "${clone_dir}/.git" ]]; then
+    log "refreshing existing clone at ${clone_dir}"
+    git -C "${clone_dir}" fetch origin
+    # Default branch may not exist yet on a brand-new empty repo; tolerate that.
+    if git -C "${clone_dir}" rev-parse --verify --quiet origin/main >/dev/null; then
+      git -C "${clone_dir}" checkout -B main origin/main
+    fi
+  else
+    log "cloning ${full_repo} into ${clone_dir}"
+    # Brand new repos may have no default branch yet; clone may print a warning
+    # but still succeed.
+    git clone "https://github.com/${full_repo}.git" "${clone_dir}" || {
+      # gh-created empty repos sometimes need an init-style first push.
+      mkdir -p "${clone_dir}"
+      git -C "${clone_dir}" init -b main
+      git -C "${clone_dir}" remote add origin "https://github.com/${full_repo}.git"
+    }
+  fi
+
+  # Make sure we're on main locally even if HEAD doesn't yet exist on remote.
+  git -C "${clone_dir}" checkout -B main 2>/dev/null || true
+
+  # Step 3: sync source-of-truth files.
+  log "syncing files into ${clone_dir}"
+
+  # README
+  cp "${readme_src}" "${clone_dir}/README.md"
+
+  # scripts/build-catalog.mjs
+  mkdir -p "${clone_dir}/scripts"
+  cp "${SRC_DIR}/build-catalog.mjs" "${clone_dir}/scripts/build-catalog.mjs"
+
+  # scripts/package.json (declares zod runtime dep for the Action)
+  cat > "${clone_dir}/scripts/package.json" <<'PKG_EOF'
+{
+  "name": "projelli-community-catalog-build",
+  "private": true,
+  "type": "module",
+  "description": "Catalog rebuild script vendored from projelli/projelli. Do not edit here.",
+  "dependencies": {
+    "zod": "^4.3.6"
+  }
+}
+PKG_EOF
+
+  # .github/workflows/build-catalog.yml
+  mkdir -p "${clone_dir}/.github/workflows"
+  cp "${SRC_DIR}/build-catalog.yml" "${clone_dir}/.github/workflows/build-catalog.yml"
+
+  # entries/ (full mirror; remove any orphaned entries no longer in seed/)
+  rm -rf "${clone_dir}/entries"
+  mkdir -p "${clone_dir}/entries"
+  if [[ -d "${seeds_src}" ]] && [[ -n "$(ls -A "${seeds_src}" 2>/dev/null)" ]]; then
+    cp -a "${seeds_src}/." "${clone_dir}/entries/"
+  fi
+
+  # catalog.json: only seed an empty array on the very first push so the
+  # marketplace can fetch a valid (if empty) response immediately. After the
+  # first push, leave the file alone so the Action keeps managing it.
+  if [[ ! -f "${clone_dir}/catalog.json" ]]; then
+    log "no catalog.json yet; seeding empty array"
+    printf '[]\n' > "${clone_dir}/catalog.json"
+  fi
+
+  # Step 4: commit + push.
+  cd "${clone_dir}"
+  git add -A
+
+  if git diff --staged --quiet; then
+    log "no changes to commit for ${full_repo}"
+    cd "${REPO_ROOT}"
+    return 0
+  fi
+
+  # Detect "first push": no commits yet on this clone.
+  local commit_msg
+  if ! git rev-parse --verify --quiet HEAD >/dev/null; then
+    # First commit ever for this repo. Skip CI so the Action doesn't loop on
+    # the initial seed import (we ship an empty catalog.json alongside seeds).
+    commit_msg="chore: initial seed sync from projelli/projelli [skip ci]
+
+Source-of-truth synced from infra/community-repos/ in projelli/projelli."
+  else
+    commit_msg="chore: sync from projelli/projelli
+
+Source-of-truth synced from infra/community-repos/ in projelli/projelli."
+  fi
+
+  git -c user.name="projelli-catalog-bot" \
+      -c user.email="bot@projelli.com" \
+      commit -m "${commit_msg}"
+
+  if [[ "${DRYRUN}" == "1" ]]; then
+    log "DRYRUN: skipping push for ${full_repo}"
+  else
+    log "pushing to ${full_repo}"
+    git push -u origin main
+  fi
+
+  cd "${REPO_ROOT}"
+}
+
+for kind in "${KINDS_TO_SYNC[@]}"; do
+  sync_one_kind "${kind}"
+done
+
+log "all done"

--- a/infra/community-repos/templates-readme.md
+++ b/infra/community-repos/templates-readme.md
@@ -1,0 +1,121 @@
+# projelli/community-templates
+
+The community catalog of workflow templates for [Projelli](https://projelli.com).
+
+Anything in this repo's `entries/` folder shows up in the in-app marketplace. Users browse, install, and run these templates from inside Projelli without ever leaving the app.
+
+## What's in here
+
+- `entries/<id>/` — one folder per template, each with a manifest, the template body, the workflow definition, the interview questions, and screenshots.
+- `catalog.json` — the marketplace index. Auto-generated from `entries/` on every push to `main`. Never hand-edit.
+- `scripts/build-catalog.mjs` — the script that regenerates `catalog.json` and per-entry tarballs. Runs in CI; you can also run it locally to validate your submission before opening a PR.
+- `.github/workflows/build-catalog.yml` — the GitHub Action that runs the script on every merge.
+
+## How to submit a template
+
+### 1. Fork this repo
+
+```
+gh repo fork projelli/community-templates
+```
+
+Or click Fork on github.com.
+
+### 2. Add your entry
+
+Create a folder under `entries/` whose name matches the `id` in your manifest:
+
+```
+entries/my-template/
+├── manifest.json
+├── template.md
+├── workflow.json
+├── questions.json
+└── screenshots/
+    └── main.png
+```
+
+The folder name MUST match `manifest.id` exactly. The build script enforces this.
+
+### 3. Author the manifest
+
+Your `manifest.json` follows the [TemplateManifest schema](https://github.com/projelli/projelli/blob/master/src/types/templateManifest.ts). Required fields:
+
+```json
+{
+  "id": "my-template",
+  "name": "My Template",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
+  "author": { "name": "Your Name", "githubUser": "your-handle" },
+  "description": "One-sentence pitch for what this template does.",
+  "category": "marketing",
+  "tags": ["copywriting", "launch"],
+  "screenshots": ["screenshots/main.png"],
+  "files": [
+    { "path": "template.md", "type": "markdown" },
+    { "path": "workflow.json", "type": "workflow-definition" },
+    { "path": "questions.json", "type": "interview-questions" }
+  ],
+  "minProjelliVersion": "2.0.0"
+}
+```
+
+`screenshots` paths are relative to your entry folder. They get rewritten to absolute `raw.githubusercontent.com/...` URLs when the catalog builds.
+
+### 4. Validate locally
+
+```
+npm install --no-save zod@^4.3.6
+PROJELLI_CATALOG_KIND=templates node scripts/build-catalog.mjs
+```
+
+If your manifest validates, the script writes `catalog.json` plus `entries/my-template/tarball.tar.gz` and `entries/my-template/checksum.txt`. If it fails, you'll see a list of validation errors. Fix and re-run.
+
+You can leave the generated tarball + checksum out of your PR; the Action regenerates them after merge.
+
+### 5. Open a PR
+
+```
+git checkout -b add-my-template
+git add entries/my-template/
+git commit -m "Add my-template v1.0.0"
+git push origin add-my-template
+gh pr create --base main
+```
+
+PR title format: `Add <template-name> v<version>`.
+
+In the description, include:
+
+- One paragraph explaining what the template produces.
+- The user this is for (founder researching pricing, writer drafting a press release, etc.).
+- A note on what makes this different from existing templates if it's similar to one already in the catalog.
+
+## Review criteria
+
+A maintainer reviews every submission. We check for:
+
+- **Schema validity.** The Action runs `build-catalog.mjs` on every PR. If it fails, the PR can't merge.
+- **Originality.** We don't accept near-duplicates of templates already in the catalog. If yours is a variant, the description should make the differentiator obvious.
+- **Quality.** The template body, workflow steps, and interview questions should produce something useful when run end-to-end. We try the template before merging.
+- **Honest description.** The pitch matches what the template actually does.
+- **Reasonable scope.** Templates that produce one focused artifact land faster than templates that try to do everything.
+
+Most reviews finish within a few days. Push another commit to the same branch if we ask for changes.
+
+## License
+
+By submitting a template, you agree to publish it under MIT or a compatible permissive license (Apache-2.0, BSD-3-Clause, ISC). Add a `LICENSE` file inside your entry folder if you want to be explicit. Closed-source templates aren't accepted.
+
+## Reporting a problem
+
+If you find a template that produces broken output, has misleading screenshots, or hasn't been updated in a long time, open an issue with the entry id and details.
+
+## Updating an existing template
+
+Bump `version` in your manifest, update the files, and open a PR with the changes. Versions don't need to be sequential; the catalog always serves the latest one.
+
+## Removing a template
+
+Open a PR that deletes the entry folder. Existing installs in user copies of Projelli keep working; the template just disappears from the marketplace.

--- a/tests/integration/marketplace-fetch-from-live-repos.test.ts
+++ b/tests/integration/marketplace-fetch-from-live-repos.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Live-network integration test for the seed catalog (Stream C6 Group VI,
+ * Task 6.1).
+ *
+ * Hits the actual `projelli/community-templates` and `projelli/community-plugins`
+ * repos on raw.githubusercontent.com and verifies the end-to-end shape:
+ *
+ *   1. catalog.json fetches with HTTP 200 and parses as CatalogEntry[].
+ *   2. Each entry has the fields the in-app marketplace UI requires
+ *      (id, name, version, installUrl, manifestUrl, checksum).
+ *   3. One real tarball downloads, and its actual SHA-256 matches the
+ *      catalog-declared checksum (catches bot drift, force pushes, or a
+ *      tampered repo).
+ *   4. The corresponding manifest.json fetches and validates against the
+ *      vendored Zod schema the in-app installer uses (templates schema for
+ *      community-templates, plugins schema for community-plugins).
+ *
+ * Gated behind `LIVE_NETWORK_OK=1` so CI does not hit GitHub on every push;
+ * Jameson runs it manually after the seed catalog is live or after merging
+ * a new catalog entry.
+ *
+ * Run locally:
+ *   LIVE_NETWORK_OK=1 npm run test -- marketplace-fetch-from-live-repos
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { validateTemplateManifest } from '@/modules/marketplace/manifestValidator';
+import { validatePluginManifest } from '@/modules/plugins/PluginManifestSchema';
+import type { CatalogEntry } from '@/types/marketplace';
+
+const LIVE_OK = process.env.LIVE_NETWORK_OK === '1';
+
+const TEMPLATES_CATALOG_URL =
+  'https://raw.githubusercontent.com/projelli/community-templates/main/catalog.json';
+const PLUGINS_CATALOG_URL =
+  'https://raw.githubusercontent.com/projelli/community-plugins/main/catalog.json';
+
+function assertCatalogShape(catalog: unknown): asserts catalog is CatalogEntry[] {
+  expect(Array.isArray(catalog)).toBe(true);
+  const arr = catalog as unknown[];
+  for (const raw of arr) {
+    expect(raw).toBeTypeOf('object');
+    const entry = raw as Record<string, unknown>;
+    expect(typeof entry.id).toBe('string');
+    expect(typeof entry.name).toBe('string');
+    expect(typeof entry.description).toBe('string');
+    expect(typeof entry.version).toBe('string');
+    expect(typeof entry.category).toBe('string');
+    expect(Array.isArray(entry.tags)).toBe(true);
+    expect(typeof entry.installUrl).toBe('string');
+    expect(typeof entry.manifestUrl).toBe('string');
+    expect(typeof entry.minProjelliVersion).toBe('string');
+    expect(typeof entry.publishedAt).toBe('string');
+    expect(typeof entry.updatedAt).toBe('string');
+    expect(typeof entry.checksum).toBe('string');
+    expect((entry.checksum as string).length).toBeGreaterThan(0);
+    expect(typeof entry.author).toBe('object');
+  }
+}
+
+async function sha256OfUrl(url: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  }
+  const buf = new Uint8Array(await res.arrayBuffer());
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+describe.skipIf(!LIVE_OK)('marketplace fetch from live community repos', () => {
+  it('fetches the live community-templates catalog with the expected shape', async () => {
+    const res = await fetch(TEMPLATES_CATALOG_URL);
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+
+    const catalog = (await res.json()) as unknown;
+    assertCatalogShape(catalog);
+    expect(catalog.length).toBeGreaterThanOrEqual(5);
+
+    for (const entry of catalog) {
+      expect(entry.installUrl).toMatch(
+        /^https:\/\/raw\.githubusercontent\.com\/projelli\/community-templates\/main\/entries\//,
+      );
+      expect(entry.installUrl).toMatch(/tarball\.tar\.gz$/);
+      expect(entry.manifestUrl).toMatch(
+        /^https:\/\/raw\.githubusercontent\.com\/projelli\/community-templates\/main\/entries\//,
+      );
+      expect(entry.manifestUrl).toMatch(/manifest\.json$/);
+    }
+  }, 30_000);
+
+  it('fetches the live community-plugins catalog with the expected shape', async () => {
+    const res = await fetch(PLUGINS_CATALOG_URL);
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+
+    const catalog = (await res.json()) as unknown;
+    assertCatalogShape(catalog);
+    expect(catalog.length).toBeGreaterThanOrEqual(4);
+
+    for (const entry of catalog) {
+      expect(entry.installUrl).toMatch(
+        /^https:\/\/raw\.githubusercontent\.com\/projelli\/community-plugins\/main\/entries\//,
+      );
+      expect(entry.installUrl).toMatch(/tarball\.tar\.gz$/);
+      expect(entry.manifestUrl).toMatch(
+        /^https:\/\/raw\.githubusercontent\.com\/projelli\/community-plugins\/main\/entries\//,
+      );
+      expect(entry.manifestUrl).toMatch(/manifest\.json$/);
+    }
+  }, 30_000);
+
+  it('downloads one real template tarball and confirms its SHA-256 matches the catalog checksum', async () => {
+    const res = await fetch(TEMPLATES_CATALOG_URL);
+    const catalog = (await res.json()) as CatalogEntry[];
+    const entry = catalog[0];
+    expect(entry).toBeDefined();
+    if (!entry) return;
+
+    const actual = await sha256OfUrl(entry.installUrl);
+    expect(actual).toBe(entry.checksum);
+  }, 60_000);
+
+  it('downloads one real plugin tarball and confirms its SHA-256 matches the catalog checksum', async () => {
+    const res = await fetch(PLUGINS_CATALOG_URL);
+    const catalog = (await res.json()) as CatalogEntry[];
+    const entry = catalog[0];
+    expect(entry).toBeDefined();
+    if (!entry) return;
+
+    const actual = await sha256OfUrl(entry.installUrl);
+    expect(actual).toBe(entry.checksum);
+  }, 60_000);
+
+  it('fetches a real template manifest.json and validates it against the in-app Zod schema', async () => {
+    const res = await fetch(TEMPLATES_CATALOG_URL);
+    const catalog = (await res.json()) as CatalogEntry[];
+    const entry = catalog[0];
+    expect(entry).toBeDefined();
+    if (!entry) return;
+
+    const manifestRes = await fetch(entry.manifestUrl);
+    expect(manifestRes.ok).toBe(true);
+    const raw = (await manifestRes.json()) as unknown;
+
+    const result = validateTemplateManifest(raw);
+    if (!result.ok) {
+      throw new Error(
+        `Template manifest validation failed for ${entry.id}: ${result.errors.join(', ')}`,
+      );
+    }
+    expect(result.manifest.id).toBe(entry.id);
+    expect(result.manifest.version).toBe(entry.version);
+  }, 60_000);
+
+  it('fetches a real plugin manifest.json and validates it against the in-app Zod schema', async () => {
+    const res = await fetch(PLUGINS_CATALOG_URL);
+    const catalog = (await res.json()) as CatalogEntry[];
+    const entry = catalog[0];
+    expect(entry).toBeDefined();
+    if (!entry) return;
+
+    const manifestRes = await fetch(entry.manifestUrl);
+    expect(manifestRes.ok).toBe(true);
+    const raw = (await manifestRes.json()) as unknown;
+
+    const result = validatePluginManifest(raw);
+    if (!result.ok) {
+      throw new Error(
+        `Plugin manifest validation failed for ${entry.id}: ${result.errors.join(', ')}`,
+      );
+    }
+    expect(result.manifest.id).toBe(entry.id);
+    expect(result.manifest.version).toBe(entry.version);
+  }, 60_000);
+});
+
+describe.skipIf(LIVE_OK)('marketplace fetch from live community repos (skipped)', () => {
+  it('is gated behind LIVE_NETWORK_OK=1 to keep CI offline', () => {
+    expect(LIVE_OK).toBe(false);
+  });
+});

--- a/tests/unit/website-content-lint.test.ts
+++ b/tests/unit/website-content-lint.test.ts
@@ -47,6 +47,8 @@ const TARGETS = [
   'docs/plugins/api-reference.html',
   'docs/plugins/publishing.html',
   'docs/plugins/examples.html',
+  // Stream C6 (v2.0) — marketplace submission docs.
+  'docs/marketplace-submissions.html',
 ];
 
 const BANNED_WORDS = [

--- a/website/docs/marketplace-submissions.html
+++ b/website/docs/marketplace-submissions.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Marketplace Submissions, Projelli</title>
+  <meta name="description" content="How to submit a template or plugin to the Projelli in-app marketplace via pull request.">
+  <link rel="canonical" href="https://projelli.com/docs/marketplace-submissions">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer data-domain="projelli.com" src="https://analytics.jamesondaines.com/js/script.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #475569; line-height: 1.7; padding: 60px 24px; }
+    .container { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 2.25rem; color: #111F35; margin-bottom: 8px; font-weight: 800; }
+    h2 { font-size: 1.5rem; color: #111F35; margin-top: 48px; margin-bottom: 16px; font-weight: 700; }
+    h3 { font-size: 1.125rem; color: #111F35; margin-top: 24px; margin-bottom: 8px; font-weight: 600; }
+    p, ul, ol { margin-bottom: 16px; font-size: 1rem; }
+    ul, ol { padding-left: 24px; }
+    li { margin-bottom: 8px; }
+    strong { color: #111F35; font-weight: 600; }
+    a { color: #3B82F6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { color: #94A3B8; font-size: 0.875rem; margin-bottom: 32px; }
+    .back { display: inline-block; margin-bottom: 32px; font-size: 0.875rem; }
+    .step { background: #F8FAFC; border-left: 3px solid #3B82F6; padding: 20px 24px; margin: 24px 0; border-radius: 4px; }
+    .step h3 { margin-top: 0; color: #3B82F6; }
+    code { background: #F1F5F9; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.875em; }
+    pre { background: #0F172A; color: #E2E8F0; padding: 16px 20px; border-radius: 8px; overflow-x: auto; margin: 16px 0; font-size: 0.875rem; line-height: 1.5; }
+    pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; }
+    .callout { background: #FEF3C7; border-left: 3px solid #F59E0B; padding: 16px 20px; margin: 24px 0; border-radius: 4px; font-size: 0.9375rem; }
+    .callout strong { color: #92400E; }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.9375rem; }
+    th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #E2E8F0; }
+    th { color: #111F35; font-weight: 600; background: #F8FAFC; }
+    .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
+    .next-link:hover { text-decoration: none; opacity: 0.9; }
+    .repo-cta { display: flex; gap: 16px; flex-wrap: wrap; margin: 24px 0; }
+    .repo-cta a { display: inline-block; padding: 12px 20px; background: #111F35; color: #fff !important; border-radius: 8px; font-weight: 600; }
+    .repo-cta a:hover { text-decoration: none; opacity: 0.9; }
+  </style>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/styles/projelli-nav.css">
+  <script src="/scripts/projelli-nav.v2.js" defer></script>
+</head>
+<body>
+  <div class="container">
+    <a href="/" class="back">&larr; Back to Projelli</a>
+    <h1>Marketplace Submissions</h1>
+    <p class="meta">How to publish a template or plugin to the in-app marketplace.</p>
+
+    <p>The Projelli marketplace is two public GitHub repos. Templates live at <a href="https://github.com/projelli/community-templates" target="_blank" rel="noopener"><code>projelli/community-templates</code></a>, plugins at <a href="https://github.com/projelli/community-plugins" target="_blank" rel="noopener"><code>projelli/community-plugins</code></a>. Each entry is one folder under <code>entries/</code> with a manifest, the entry's files, and screenshots. To publish, you fork the relevant repo, add your folder, and open a pull request.</p>
+
+    <div class="callout">
+      <strong>Why publish-via-PR?</strong> The repo is the source of truth. There's no signup, no API key, no separate dashboard. Every catalog entry has a public commit history and a maintainer who reviewed it. If you can write a manifest and open a PR, you can ship to the marketplace.
+    </div>
+
+    <div class="repo-cta">
+      <a href="https://github.com/projelli/community-templates" target="_blank" rel="noopener">community-templates repo</a>
+      <a href="https://github.com/projelli/community-plugins" target="_blank" rel="noopener">community-plugins repo</a>
+    </div>
+
+    <h2>Prerequisites</h2>
+
+    <ul>
+      <li>A working template or plugin tested locally inside Projelli.</li>
+      <li>A unique <code>id</code> in your manifest that doesn't collide with any existing entry.</li>
+      <li>An open-source license (MIT, Apache-2.0, BSD-3-Clause, or similar). Closed-source entries aren't accepted.</li>
+      <li>At least one screenshot.</li>
+      <li>A GitHub account.</li>
+    </ul>
+
+    <h2>Step 1: Pick the right repo</h2>
+
+    <p>Templates and plugins live in different repos because they have different schemas and different review criteria.</p>
+
+    <ul>
+      <li><strong>Template:</strong> a workflow definition plus a markdown body that produces one or more files when run. No code. Use <a href="https://github.com/projelli/community-templates" target="_blank" rel="noopener">community-templates</a>.</li>
+      <li><strong>Plugin:</strong> a JavaScript bundle that runs inside Projelli's sandboxed worker and contributes commands, toolbar buttons, sidebar panels, or settings. Use <a href="https://github.com/projelli/community-plugins" target="_blank" rel="noopener">community-plugins</a>.</li>
+    </ul>
+
+    <h2>Step 2: Fork the repo and add your entry</h2>
+
+    <pre><code>gh repo fork projelli/community-templates  # or community-plugins
+cd community-templates
+git checkout -b add-my-entry</code></pre>
+
+    <p>Create a folder under <code>entries/</code> matching your manifest's <code>id</code>:</p>
+
+    <div class="step">
+      <h3>Templates layout</h3>
+      <pre><code>entries/my-template/
+  manifest.json
+  template.md
+  workflow.json
+  questions.json
+  screenshots/
+    main.png</code></pre>
+    </div>
+
+    <div class="step">
+      <h3>Plugins layout</h3>
+      <pre><code>entries/my-plugin/
+  manifest.json
+  index.js          (your built bundle)
+  screenshots/
+    main.png</code></pre>
+    </div>
+
+    <p>The folder name must exactly match <code>manifest.id</code>. The build script enforces this.</p>
+
+    <h2>Step 3: Author the manifest</h2>
+
+    <p>Templates use the <a href="https://github.com/projelli/projelli/blob/master/src/types/templateManifest.ts" target="_blank" rel="noopener">TemplateManifest schema</a>; plugins use the <a href="https://github.com/projelli/projelli/blob/master/src/types/plugin.ts" target="_blank" rel="noopener">PluginManifest schema</a>. Both repos' READMEs show a complete example.</p>
+
+    <p>Fields you'll always need: <code>id</code>, <code>name</code>, <code>version</code> (semver), <code>apiVersion</code>, <code>author</code>, <code>description</code>, <code>category</code>, <code>tags</code>, and <code>minProjelliVersion</code>.</p>
+
+    <p>Plugins additionally declare <code>main</code> (the JS entry path) and <code>permissions</code> (what host capabilities the plugin needs). See the <a href="/docs/plugins/permissions">permissions reference</a> for details on which permissions are surfaced to the user at install time and how to keep that list short.</p>
+
+    <h2>Step 4: Validate locally</h2>
+
+    <p>Both repos ship the same <code>scripts/build-catalog.mjs</code>. Run it from the repo root:</p>
+
+    <pre><code>npm install --no-save zod@^4.3.6
+
+# templates repo
+PROJELLI_CATALOG_KIND=templates node scripts/build-catalog.mjs
+
+# plugins repo
+PROJELLI_CATALOG_KIND=plugins node scripts/build-catalog.mjs</code></pre>
+
+    <p>If your manifest validates, the script writes <code>catalog.json</code> plus a tarball and checksum inside your entry folder. If it fails, you'll see a list of validation errors with the field path and reason. Fix and re-run.</p>
+
+    <p>You can leave the generated tarball and checksum out of your PR; the GitHub Action regenerates them after merge so the catalog stays consistent.</p>
+
+    <h2>Step 5: Open a pull request</h2>
+
+    <pre><code>git add entries/my-entry/
+git commit -m "Add my-entry v1.0.0"
+git push origin add-my-entry
+gh pr create --base main</code></pre>
+
+    <p>Use this title format: <code>Add &lt;name&gt; v&lt;version&gt;</code>.</p>
+
+    <p>In the PR description, include:</p>
+
+    <ul>
+      <li>One paragraph on what the entry does and who it's for.</li>
+      <li>For plugins: the list of permissions you declared, with one sentence per permission explaining why you need it.</li>
+      <li>For plugins that declare <code>network</code>: which hosts the plugin contacts and what data is sent.</li>
+      <li>A link to your source repo if it's public.</li>
+    </ul>
+
+    <h2>Step 6: Review</h2>
+
+    <p>A maintainer reviews every submission. Reviews focus on:</p>
+
+    <ul>
+      <li><strong>Schema valid.</strong> The Action runs <code>build-catalog.mjs</code> on every PR. If it fails, the PR can't merge.</li>
+      <li><strong>Honest description.</strong> The pitch matches what the entry actually does.</li>
+      <li><strong>Reasonable scope.</strong> Entries that do one focused thing land faster than ones that try to do everything.</li>
+      <li><strong>Plugin code is readable.</strong> The bundle isn't obfuscated to hide behavior. Source maps or a linked source repo help.</li>
+      <li><strong>No secrets.</strong> No hardcoded API keys, tokens, or credentials in the bundle.</li>
+      <li><strong>Permissions match behavior.</strong> What a plugin declares matches what its bundle actually does.</li>
+      <li><strong>Original.</strong> We don't accept near-duplicates of existing entries unless the differentiator is obvious.</li>
+    </ul>
+
+    <p>Most reviews finish within a few days. If we ask for changes, push another commit to the same branch and the PR updates automatically. Once merged, the Action regenerates <code>catalog.json</code> and your entry appears in the in-app marketplace on the next refresh.</p>
+
+    <h2>Updating an existing entry</h2>
+
+    <p>Bump <code>version</code> in your manifest, update the files, and open a PR. Don't change the entry's <code>id</code> or rename the folder; that breaks installs for users on the old version.</p>
+
+    <h2>Removing an entry</h2>
+
+    <p>Open a PR that deletes the entry folder. Existing installs in user copies of Projelli keep working; the entry just disappears from the marketplace.</p>
+
+    <h2>Reporting a problem</h2>
+
+    <p>If you find an entry that's broken, misleading, or doing something it shouldn't be doing, open an issue on the relevant repo with the entry id and details. We take takedowns seriously when a plugin violates the trust model.</p>
+
+    <a href="/docs/plugins/publishing" class="next-link">Plugin-specific publishing guide &rarr;</a>
+  </div>
+</body>
+</html>

--- a/website/docs/plugins/publishing.html
+++ b/website/docs/plugins/publishing.html
@@ -34,6 +34,9 @@
     .callout strong { color: #92400E; }
     .next-link { display: inline-block; margin-top: 24px; padding: 12px 24px; background: linear-gradient(135deg, #3B82F6 0%, #7C3AED 100%); color: white !important; border-radius: 8px; font-weight: 600; }
     .next-link:hover { text-decoration: none; opacity: 0.9; }
+    .repo-cta { display: flex; gap: 16px; flex-wrap: wrap; margin: 16px 0 32px; }
+    .repo-cta a { display: inline-block; padding: 12px 20px; background: #111F35; color: #fff !important; border-radius: 8px; font-weight: 600; }
+    .repo-cta a:hover { text-decoration: none; opacity: 0.9; }
   </style>
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -50,8 +53,13 @@
 
     <p>The Projelli marketplace is a public GitHub repository, <a href="https://github.com/projelli/community-plugins" target="_blank" rel="noopener"><code>projelli/community-plugins</code></a>. Each plugin is one folder under <code>entries/</code>, containing the manifest, the built bundle, and screenshots. To publish, fork the repo, add your entry, and open a pull request. After review, your plugin appears in the in-app marketplace and users can install it with one click.</p>
 
+    <div class="repo-cta">
+      <a href="https://github.com/projelli/community-plugins" target="_blank" rel="noopener">Fork projelli/community-plugins on GitHub</a>
+      <a href="/docs/marketplace-submissions">General submission guide</a>
+    </div>
+
     <div class="callout">
-      <strong>Before you start:</strong> publish-via-PR keeps the marketplace lightweight and reviewable. There's no signup, no API key, no separate dashboard. The repo is the source of truth.
+      <strong>Before you start:</strong> publish-via-PR keeps the marketplace lightweight and reviewable. There's no signup, no API key, no separate dashboard. The repo is the source of truth. The general flow (templates and plugins) is documented at <a href="/docs/marketplace-submissions">Marketplace Submissions</a>; this page covers the plugin-specific bits.
     </div>
 
     <h2>Prerequisites</h2>
@@ -71,14 +79,13 @@
     <pre><code>git clone https://github.com/&lt;your-username&gt;/community-plugins.git
 cd community-plugins</code></pre>
 
-    <h2>Step 2: Build a release tarball</h2>
+    <h2>Step 2: Build your bundle</h2>
 
     <p>From your plugin project, run:</p>
 
-    <pre><code>npm run build
-tar -czf my-plugin-1.0.0.tgz manifest.json dist/</code></pre>
+    <pre><code>npm run build</code></pre>
 
-    <p>The tarball must contain <code>manifest.json</code> at the top level and the <code>dist/</code> folder with your built bundle. Nothing else.</p>
+    <p>This produces <code>dist/index.js</code> (the bundled worker entry the runtime loads).</p>
 
     <h2>Step 3: Add your entry</h2>
 
@@ -86,22 +93,21 @@ tar -czf my-plugin-1.0.0.tgz manifest.json dist/</code></pre>
 
     <pre><code>entries/my-plugin/
   manifest.json           &larr; copy of your plugin's manifest
-  my-plugin-1.0.0.tgz     &larr; the tarball you built
+  index.js                &larr; copy of your built bundle (from dist/index.js)
   screenshots/
     main.png              &larr; 1280x800 PNG, primary screenshot
-    settings.png          &larr; optional, additional screenshots
-  README.md               &larr; same README that ships in your plugin</code></pre>
+    settings.png          &larr; optional, additional screenshots</code></pre>
 
-    <p>The folder name must match the <code>id</code> field in your manifest.</p>
+    <p>The folder name must match the <code>id</code> field in your manifest. The repo's GitHub Action regenerates the installable tarball and SHA-256 checksum on merge, so you don't need to ship those yourself.</p>
 
     <h2>Step 4: Verify locally</h2>
 
-    <p>Run the marketplace's verification script from the repo root:</p>
+    <p>Run the marketplace's build script from the repo root:</p>
 
-    <pre><code>npm install
-npm run verify entries/my-plugin</code></pre>
+    <pre><code>npm install --no-save zod@^4.3.6
+PROJELLI_CATALOG_KIND=plugins node scripts/build-catalog.mjs</code></pre>
 
-    <p>This checks: manifest validation, tarball contents, screenshot dimensions, license file, README presence. Fix any errors before opening the PR.</p>
+    <p>This validates every <code>manifest.json</code> against the production schema, builds a deterministic tarball per entry, and writes <code>catalog.json</code>. If validation fails you'll see the field path and reason. Fix any errors before opening the PR.</p>
 
     <h2>Step 5: Open a pull request</h2>
 


### PR DESCRIPTION
## Summary

The two community-content GitHub repos for Projelli's marketplace are now live, seeded, and feeding the in-app Marketplace UI. `projelli/community-templates` ships with 6 hand-curated templates (beta-user-survey, cold-email-sequence, customer-discovery-interview, investor-update-email-community, launch-announcement-tweet-thread, press-release). `projelli/community-plugins` ships with 4 working plugins built from the C5 example projects (mermaid-preview, pomodoro, translator, word-counter). Anyone opening Settings -> Marketplace sees real entries on day one, and the submission process is documented in two places (the live repo READMEs + projelli.com/docs/marketplace-submissions).

This PR is the capstone of Stream C. With it merged, Stream C is COMPLETE for v2.0: templates marketplace (C1) + plugin runner (C3) + plugin marketplace UI (C4) + plugin developer experience (C5) + this seed catalog (C6) all working end-to-end with live content.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-28-v2.0-mega-release-design.md` section 6.8
- Plan: `docs/superpowers/plans/2026-05-03-stream-c6-seed-catalog.md`

## Live URLs

- https://github.com/projelli/community-templates
- https://github.com/projelli/community-plugins
- https://raw.githubusercontent.com/projelli/community-templates/main/catalog.json (6 entries)
- https://raw.githubusercontent.com/projelli/community-plugins/main/catalog.json (4 entries)

## Smoke test (Jameson)

```
cd ~/projelli-worktrees/stream-c6-seed-catalog
npm run tauri:dev
```

Then in the running app:

- [ ] Open Settings -> Marketplace -> Templates. See 6 community templates listed.
- [ ] Click any template -> Install. Confirm it appears in WorkflowPanel under the Community section.
- [ ] Switch to the Plugins subtab. See 4 community plugins.
- [ ] Click any plugin -> see the consent dialog with declared permissions -> Approve. Plugin auto-enables and its toolbar button or sidebar panel appears.
- [ ] Verify the sum nav badge updates correctly.

## Tests

- `npm run typecheck`: clean
- `npm run test`: 166 files, 1845 passed, 6 skipped (the 6 live-network tests that gate on `LIVE_NETWORK_OK=1`)
- `npm run lint`: no new errors from Stream C6 (pre-existing baseline unchanged)
- New live-network test: `tests/integration/marketplace-fetch-from-live-repos.test.ts`. Run locally with `LIVE_NETWORK_OK=1 npm run test -- marketplace-fetch-from-live-repos`. Verifies both live catalogs parse, one real tarball from each repo downloads and its actual SHA-256 matches the catalog-declared checksum, and one real manifest from each validates against the in-app Zod schema. All 6 live tests pass against the real repos.

## Notes

- Screenshots in seed entries are placeholders. Jameson can swap real PNGs into `infra/community-repos/seed-{templates,plugins}/<id>/screenshots/` and re-run `sync-to-github.sh` without code edits.
- 6 templates were picked from a longer plan list. Jameson can swap entries in `infra/community-repos/seed-templates/` and re-run `sync-to-github.sh` to redeploy.
- Future hardening (separate ticket): CODEOWNERS + branch protection rules on both community repos.

## Stream C status after merge

```
C1  templates marketplace      MERGED
C3  plugin runner              MERGED
C4  plugin marketplace UI      MERGED
C5  plugin developer experience MERGED
C6  seed catalog (this PR)     READY
```

Stream C complete for v2.0.

Generated with Claude Code.