### PR TITLE
Pricing/positioning sweep: sitewide consistency + canonical spec

### DIFF
--- a/KEEPANCE_BUSINESS_PLAN.md
+++ b/KEEPANCE_BUSINESS_PLAN.md
@@ -203,16 +203,22 @@ Jameson asked Claude to make every call. Each row below is a decision, the reaso
 
 ---
 
-### Decision 2: Pricing — one-time, $49 / $99, with a launch tier
+### Decision 2: Pricing, one-time, $49 / $129 / $399, with a charter tier
+
+> **Updated 2026-05-29 to the locked post-pivot model.** The original indie-founder table (Free / Pro $49 / Lifetime $99 / Founder's $29) is retired; see the Board Record at the top of this file. The permanent free tier and the Lifetime tier no longer exist. Pricing is now three one-time tiers plus a charter offer, sold via LemonSqueezy, with a 30-day free trial in place of a permanent free tier. Canonical detail lives in `docs/reference/PRICING_AND_POSITIONING.md`.
 
 **Decision:**
 
 | Tier | Price | What you get |
 |---|---|---|
-| **Free** | $0 | Core editor, file tree, Markdown, wiki-links, version history, audit log, **1 AI provider (Claude only)**, **3 templates**, **1 workspace** |
-| **Pro** | **$49 one-time** | Everything Free has + **all 3 AI providers** + **all 15 templates** + **unlimited workspaces** + whiteboard + audio + research/citations + multi-model comparison + **1 year of updates** |
-| **Lifetime** | **$99 one-time** | Everything Pro has + **updates forever** + **early access to new features** + **commercial use license** |
-| **Founder's Launch (first 100 buyers)** | **$29 lifetime** | Same as Lifetime, but capped at 100 sales. Creates urgency, rewards early adopters. |
+| **Personal** | **$49 one-time** | Full app for general confidential work: editor, file tree, Markdown, wiki-links, backlinks, version history, audit log, **all four AI providers (Claude / OpenAI / Gemini / Ollama, BYOK)**, whiteboard, audio, research/citations, multi-model comparison, unlimited workspaces, **single seat**. **No profession practice pack** (you bring your own templates). Updates and security patches for the life of the product. |
+| **Professional** | **$129 one-time** | Everything in Personal, **plus one profession practice pack** (Legal / Tax / Consulting). That pack is the structured AI interviews that produce the actual documents a practice writes. **This is the tier we sell.** Single seat. Priority access to new packs as they ship. |
+| **Practice** | **$399 one-time** | Everything in Professional, **up to 5 seats**, **all three practice packs**, white-label template customization, email support, priority access to new packs. |
+| **Charter (first 100 Professional buyers per pack)** | **$89 one-time** | Professional at $89 instead of $129. Capped at 100 sales per profession pack. Creates launch urgency, rewards early adopters, and seeds the testimonials each pack needs. Replaces the retired $29 Founder's Launch. |
+
+**Trial / license:** 30-day free trial, no credit card. One-time purchase, perpetual license. Updates and security patches included for the life of the product. New profession packs are sold separately. 14-day refund after purchase.
+
+**Why Personal is deliberately a "starter," not a discount Professional:** Personal and Professional run the same app, so the only thing separating them is the profession pack. That's intentional, and it's also a cannibalization risk if we let Personal look like "Professional minus $80." The fix is positioning, not feature-crippling: **Personal is sold as the general-purpose tool ("bring your own templates"), Professional is sold as "your profession, done for you."** A solo attorney choosing between them isn't comparing two feature sets, they're deciding whether they want to write their own engagement-letter scaffolding from a blank page (Personal) or have the Legal pack run the interview and produce the draft (Professional). Framed that way, the buyer who is actually our ICP self-selects into Professional, and Personal becomes the honest entry point for the general "I just want a private AI workspace" buyer who was never going to pay for a pack anyway. We do **not** gate AI providers or core features to force the upgrade. That punishes the wrong people and reads as petty. The pack is the line.
 
 **Sold via LemonSqueezy** as merchant of record.
 
@@ -223,15 +229,17 @@ Jameson asked Claude to make every call. Each row below is a decision, the reaso
 - The most successful local-first tools all use one-time pricing: Obsidian (free + paid sync addon), Sublime Text ($99 one-time), Things ($50 one-time per platform), BBEdit ($60 one-time). The ones that try subscription struggle (Reflect, Tana).
 - Subscription billing infrastructure (renewals, dunning, cancellation flows, upgrade paths) is a ~10x more complex commercial pipe than one-time.
 
-*Why $49:*
-- Notion paid plans start at $10/mo. ChatGPT Plus is $20/mo. $49 = 2.5 months of ChatGPT Plus.
-- Sublime Text is $99 one-time. Keepance is cheaper because it's newer and unproven.
-- $49 is in the "impulse buy" zone for indie tools (typically $20–60). Above $60 needs a sales process.
-- Leaves room to raise to $59 / $69 later as the brand strengthens.
+*Why $129 anchors the lineup (and $49 / $399 bracket it):*
+- The ICP shifted from hobbyist indie founders to billing professionals (attorneys, CPAs, consultants). For someone who bills $200-400/hr, $129 once is a rounding error, and a perpetual license they own outright is exactly what a confidentiality-bound professional wants. The old $49 indie anchor under-priced the profession packs, which are the real value.
+- Anchoring on Professional $129 is consistent everywhere: the homepage compares "Keepance Professional $129 one-time" against ChatGPT/Notion/Claude subscriptions, and the /vs/ comparison pages run the same $129 + BYOK math.
+- $49 Personal stays as the honest floor for the general "I just want a private workspace, no pack" buyer, and as the contrast point against free tools (Obsidian, Logseq) on the comparison pages. It is not the tier we push.
+- $399 Practice (up to 5 seats) captures small firms and is the natural multi-seat step; per-seat it undercuts any subscription stack.
+- Room remains to raise Professional to $149 later as the packs prove out and the testimonial wall fills.
 
-*Why a free tier exists at all:*
-- Local-first/BYOK products live or die on word of mouth. People need to be able to TRY it before they trust it with their business documents.
-- Free tier is intentionally limited so there's a real reason to upgrade — only 1 AI provider, only 3 templates, only 1 workspace. Not crippled, but obviously a "starter" version.
+*Why a 30-day trial instead of a permanent free tier:*
+- The permanent free tier was retired in the pivot. A free-forever tier made sense for a viral indie tool; it makes less sense for a professional tool where the buyer expects to pay for software that touches client work.
+- Local-first/BYOK products still live or die on word of mouth, so people must be able to TRY before trusting it with confidential documents. A 30-day trial (full app, no credit card) does that without giving the product away.
+- The trial is the top-of-funnel; the charter $89 offer is the conversion hook. Together they replace the old "free tier to upgrade" motion with "trial to charter to Professional."
 
 *Why LemonSqueezy over Stripe:*
 - LemonSqueezy is the **merchant of record**, meaning they handle EU VAT, US sales tax, refunds, chargebacks, customer accounts, and license key generation as a built-in feature.
@@ -239,10 +247,10 @@ Jameson asked Claude to make every call. Each row below is a decision, the reaso
 - Lemon Squeezy has a built-in license key system that integrates directly with Tauri apps via webhook + API.
 - Same tier as Paddle, but LemonSqueezy has a better indie-developer reputation and a better dashboard.
 
-*Why a launch tier:*
-- "Founder's Pricing" creates urgency on launch day
-- Rewards early adopters (who become evangelists)
-- Generates initial revenue + reviews
+*Why a charter tier:*
+- Charter pricing ($89 Professional, first 100 per pack) creates urgency on launch day
+- Rewards early adopters (who become evangelists and the first testimonials each pack needs)
+- Generates initial revenue + reviews, capped so it doesn't permanently discount the anchor price
 - Anchors people to the higher regular price
 - Standard playbook used by every successful indie launch
 
@@ -498,12 +506,13 @@ Root-level Markdown files reduced to: `README.md`, `CHANGELOG.md`, `BACKLOG.md`,
 
 | Tier | Price | Use case | % of buyers (projected) |
 |---|---|---|---|
-| Free | $0 | Trial, intro | 80% |
-| Pro | $49 one-time | Most paying users | 60% of paying |
-| Lifetime | $99 one-time | Power users, evangelists | 30% of paying |
-| Founder's Launch | $29 lifetime (capped at 100) | Launch buyers only | 10% of paying (during launch only) |
+| Trial | $0 (30 days) | Try before buying; no permanent free tier | n/a (not a tier) |
+| Personal | $49 one-time | General private-workspace buyers, no pack needed | 25% of paying |
+| Professional | $129 one-time | The core tier, one profession pack | 60% of paying |
+| Practice | $399 one-time | Small firms, up to 5 seats, all packs | 15% of paying |
+| Charter | $89 one-time (capped at 100/pack) | Launch buyers (counts within Professional) | first 100 Professional buyers per pack |
 
-**Average revenue per paying user (steady state):** ~$64 ((60% × $49) + (30% × $99) + (10% × $29))
+**Average revenue per paying user (steady state):** ~$166 ((25% × $49) + (60% × $129) + (15% × $399)). During launch, Charter buyers pay $89 instead of $129 for the first 100 per pack, so early ARPU runs lower until the charter caps fill.
 
 ### Revenue trajectory (conservative)
 
@@ -585,7 +594,7 @@ At $5K/mo revenue, Keepance's gross margin is ~94%. Compare to a SaaS with infra
 
 **Goal:** Take money.
 
-- [ ] LemonSqueezy product setup (Free/Pro/Lifetime/Founder's Launch tiers)
+- [ ] LemonSqueezy product setup (Personal $49 / Professional $129 / Practice $399 tiers; no free or Lifetime tier)
 - [ ] Build the license validation Bun service at `licenses.keepance.com`
 - [ ] In-app activation flow: settings screen → license key input → validate → store activation token
 - [ ] Tier-gating logic: free vs paid feature checks throughout the app
@@ -608,7 +617,7 @@ At $5K/mo revenue, Keepance's gross margin is ~94%. Compare to a SaaS with infra
 
 - [ ] Product Hunt launch (Tuesday or Wednesday, optimal slot)
 - [ ] Show HN post simultaneously
-- [ ] Coordinate the "Founder's Launch" $29 lifetime tier — capped at 100 buyers
+- [ ] Coordinate the Charter offer: Professional at $89 (instead of $129), capped at first 100 buyers per profession pack
 - [ ] All hands on deck for support / responding to comments
 - [ ] Email the (small) list with launch announcement
 

--- a/docs/operations/LAUNCH_CHECKOUT_RUNBOOK.md
+++ b/docs/operations/LAUNCH_CHECKOUT_RUNBOOK.md
@@ -1,0 +1,68 @@
+# Launch Runbook: Checkout, Charter, and App Gating
+
+**Why this exists:** These are the irreversible / money-and-auth steps that were deliberately NOT done unattended overnight on 2026-05-29. They touch real payments, license issuance, and a live deploy. Do them together, awake, with Jameson clicking the confirm buttons. Estimated time together: ~1 hour.
+
+**Do not** run any of this solo or on a timer. A backup of the repo does not undo a botched live transaction, a mis-issued license key, or a down store.
+
+---
+
+## Pre-flight
+
+- [ ] Confirm canonical pricing in `docs/reference/PRICING_AND_POSITIONING.md` is still what we want.
+- [ ] Confirm working tree is clean and on a review branch (see git section).
+- [ ] Have the LemonSqueezy dashboard open and logged in.
+
+## Step 1 — LemonSqueezy products (Jameson drives the dashboard)
+
+Existing variant IDs found in commented-out buy buttons:
+- Professional ($129): `33cd497b-bffd-404c-910e-f8dd1f4453bd`
+- Practice ($399): `9a5a7f48-0ffe-448a-a1af-889af99a0f47`
+
+- [ ] Confirm those two variants exist, are priced correctly, and are set to a 30-day free trial where applicable.
+- [ ] Create/confirm the **Personal $49** variant. Record its ID here: `__________`.
+- [ ] Decide how the **$89 charter** is implemented. Two clean options:
+  - **A (recommended):** a separate "Professional (Charter)" variant at $89, manually capped at 100 sales per pack via LemonSqueezy's quantity limit. Simplest, visible, auto-closes.
+  - **B:** a discount code that expires after 100 redemptions. More fragile (per-pack cap is harder).
+  - Record charter variant/code: `__________`.
+- [ ] Confirm merchant-of-record tax settings, refund policy (14-day), and license-key generation are enabled.
+- [ ] Test-purchase each product in LemonSqueezy **test mode**, confirm a license key is issued. Do NOT skip test mode.
+
+## Step 2 — Restore buy buttons in the website
+
+All buy buttons are currently commented-out TODOs. Once Step 1 verifies in test mode AND you're ready for real money:
+
+- [ ] `website/legal/index.html`: lines ~540, ~692 (Professional), ~709 (Practice).
+- [ ] `website/tax/index.html`: lines ~523, ~658 (Professional), ~678 (Practice).
+- [ ] `website/consulting/index.html`: lines ~519, ~654 (Professional), ~671 (Practice).
+- [ ] `website/index.html`: lines ~628 (Professional), ~645 (Practice). Add a Personal $49 buy button using the new variant ID.
+- [ ] Swap the "Reserve the $89 founding price" links for real charter checkout once the charter variant exists.
+- [ ] Keep the "30-day free trial / download" CTA as the primary for cold traffic; buy buttons are for warm/decided buyers.
+
+## Step 3 — App license entitlement (lead dev drives, test-first)
+
+Goal: gate **only** the profession pack behind Professional+. Personal gets the full app minus packs. Do NOT gate AI providers or core features.
+
+- [ ] Locate the license/entitlement check in `src-tauri/` and `src/` (search: `license`, `entitlement`, `tier`, `lemonsqueezy`, `activate`).
+- [ ] Write tests first: Personal key → app works, packs locked; Professional key → one pack unlocked; Practice key → all packs + 5 seats.
+- [ ] Implement the gate to match the tests.
+- [ ] Verify against the running app (see the `verify` / `run` skills), not just unit tests. Activate with a real test-mode key from Step 1.
+- [ ] Confirm the "bring your own templates" path works for Personal (no pack, but user can create/import their own).
+
+## Step 4 — Schema.org + final copy sync
+
+- [ ] Confirm `website/index.html` Schema offers still list Personal 49 / Professional 129 / Practice 399.
+- [ ] Confirm no FORBIDDEN strings reintroduced (grep list in the pricing spec, section 8).
+
+## Step 5 — Deploy (Jameson runs it, or supervises)
+
+- [ ] **Use the correct deploy script: `infra/deploy.sh`** (CLAUDE.md canonical). It rsyncs `website/` → `/var/www/keepance.com` and purges the Cloudflare cache. `website/` is where all real content lives, so this is right.
+  - ⚠️ **DANGER, stale duplicate:** `infra/deploy-keepance.sh` points `WEBSITE_DIR` at `website-keepance/`, which contains only `index.html` + `logoideas.html`. If anyone runs `deploy-keepance.sh`, it will `rsync --delete` a near-empty directory over the live site and **wipe keepance.com**. Recommend deleting or neutering `deploy-keepance.sh` so it can't be run by mistake. Do NOT run it.
+- [ ] Dry-run first: `infra/deploy.sh` supports `--dry-run` (previews rsync without touching disk). Run that and eyeball the file list before the real run.
+- [ ] Real deploy (Jameson runs): `infra/deploy.sh`.
+- [ ] After deploy: load keepance.com, /vs/chatgpt, /legal/, /tax/, /consulting/ and confirm pricing + buy buttons render correctly (remember Caddy catch-all can mask broken URLs, check page bodies, not just 200s).
+
+## Rollback
+
+- [ ] Website: re-deploy previous commit, or `git revert` the buy-button commit and re-deploy.
+- [ ] LemonSqueezy: switch products back to draft / disable checkout.
+- [ ] App gating: revert the entitlement commit; ship a patch build if a release already went out.

--- a/docs/reference/PRICING_AND_POSITIONING.md
+++ b/docs/reference/PRICING_AND_POSITIONING.md
@@ -1,0 +1,88 @@
+# Keepance Pricing & Positioning, Canonical Spec
+
+**Status:** Source of truth as of 2026-05-29. Supersedes any pricing language elsewhere.
+**Owner:** Jameson Daines.
+**Scope:** This is the authoritative reference for every price, tier, promo, and positioning line that appears in marketing copy, the app, the store (LemonSqueezy), Schema.org, and the business plan. If any other file disagrees with this one, this file wins and the other file is a bug.
+
+---
+
+## 1. The model in one paragraph
+
+Keepance is a local-first, BYOK desktop AI workspace for confidential client work (attorneys, CPAs, independent consultants). It is sold as a **one-time purchase with a perpetual license**, no subscription. There is a **30-day free trial** (full app, no credit card) in place of a permanent free tier. The permanent free tier and the old "Lifetime $99" tier have been **retired** and must never appear in copy again.
+
+## 2. Tiers (canonical)
+
+| Tier | Price | Seats | Packs | One-line positioning |
+|---|---|---|---|---|
+| **Personal** | **$49 one-time** | 1 | None (bring your own templates) | "A private AI workspace you own." General confidential work. |
+| **Professional** | **$129 one-time** | 1 | One profession pack (Legal / Tax / Consulting) | "Your profession, done for you." **This is the tier we sell.** |
+| **Practice** | **$399 one-time** | Up to 5 | All three packs | "For the small firm." Multi-seat + every pack. |
+
+**What every tier includes:** full editor, file tree, Markdown, wiki-links, backlinks, version history, audit log, all four AI providers (Claude / OpenAI / Gemini / Ollama, BYOK), whiteboard, audio + transcription, research/citations, multi-model comparison, semantic search (LanceDB, PDFs included), local Piper read-aloud, sandboxed plugin runtime, MCP server, unlimited workspaces.
+
+**The only thing that separates Personal from Professional is the profession pack.** This is deliberate. See positioning (section 5).
+
+## 3. Charter offer (launch promo, canonical)
+
+- **Professional at $89 instead of $129**, for the **first 100 buyers of each profession pack**.
+- Capped at 100 per pack. When a pack's cap fills, that pack reverts to $129.
+- Replaces the **retired** "$29 Founder's Launch lifetime" promo (which had 0 sales and no obligation).
+- Framing: "Founding-practitioner pricing. Reserve the $89 founding price." Always honest that, pre-checkout, this is a reservation via the email list.
+
+## 4. Trial / license / refund (canonical wording)
+
+> 30-day free trial, no credit card. One-time purchase, perpetual license. Updates and security patches included for the life of the product. New profession packs sold separately. 14-day refund after purchase.
+
+## 5. Positioning: why Personal is a "starter," not a discount Professional
+
+Personal and Professional run the **same app**; the only differentiator is the profession pack. Left unframed, Personal looks like "Professional minus $80," which cannibalizes the tier we actually want to sell. The fix is **positioning, not feature-crippling**:
+
+- **Personal = "general use, bring your own templates."** The honest entry point for the buyer who just wants a private AI workspace and was never going to pay for a pack.
+- **Professional = "your profession, done for you."** The Legal/Tax/Consulting pack runs the structured AI interview and produces the actual document (engagement letter, matter strategy, etc.).
+
+A solo attorney choosing between them isn't comparing feature lists; they're deciding whether to write their own engagement-letter scaffolding from a blank page (Personal) or have the Legal pack produce the draft (Professional). Framed that way, the ICP self-selects into Professional.
+
+**We do NOT gate AI providers or core features to force the upgrade.** That punishes the wrong buyers and reads as petty. The pack is the line. (This is a standing rule for both copy and the app's entitlement logic.)
+
+## 6. Canonical copy snippets (reuse verbatim)
+
+**Price recap (one line):**
+> Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.
+
+**CTA (current pre-checkout state):**
+> Download free for 30 days, no credit card. [Download free for 30 days → /#pricing]
+
+**Charter line:**
+> Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. Reserve the founding price while checkout opens.
+
+**3-year cost anchor (for comparison pages):** Professional $129 + BYOK ~$60-180/yr = **$309-669 over 3 years**; typical (~$120/yr BYOK) ≈ **$489**. Always anchor cost comparisons on Professional $129, never on the $49 Personal floor.
+
+## 7. Heppner (use verbatim if AI-privilege is referenced)
+
+> A February 2026 S.D.N.Y. ruling (United States v. Heppner) found that consumer AI use without attorney direction offers no privilege protection.
+
+## 8. FORBIDDEN strings (never appear in any user-facing copy)
+
+`$99 Lifetime`, `Lifetime`, `$29`, `Founder's Launch`, `Pro $49` / `Pro is $49`, `free tier`, `free forever`, `free download`, `free to download`, `pay once (or zero)`, any permanent-free-tier implication. (Competitor facts like "Obsidian is free" or "Rewind $480 lifetime" are allowed, those describe other products.)
+
+## 9. Voice rules (bound to all copy)
+
+- **No em dashes (—)** in any user-facing prose. Use commas, periods, or parentheses. (Internal docs and code comments are exempt, but prefer to avoid anyway.)
+- No "It's not X, it's Y" antithesis. No "leverage / delve / seamless / transform / empower / elevate / unlock / streamline / robust / cutting-edge."
+- See `~/.claude/.../feedback_no_em_dashes.md` and `reference_ai_writing_tells.md`.
+
+## 10. System sources that must match this spec (status)
+
+| System | Current state | Action needed |
+|---|---|---|
+| `website/index.html` pricing cards | Correct ($49/$129/$399, $89 charter) | Align Personal card to "bring your own templates" line |
+| `website/{legal,tax,consulting}/index.html` | Correct; buy buttons commented out | Restore buy buttons at checkout go-live |
+| `website/vs/*.html` | Done (committed + pushed) | none |
+| LemonSqueezy products | Professional + Practice variants exist (IDs in TODO comments); checkout not public | Create/confirm Personal $49 variant + $89 charter variant; go live |
+| Schema.org (homepage) | Offers Personal 49 / Professional 129 / Practice 399 | Verify stays in sync |
+| App license entitlement | Unknown whether pack is gated to Professional | Gate ONLY the profession pack to Professional+; do not gate providers/core |
+
+**Known LemonSqueezy variant IDs (from commented buttons):**
+- Professional ($129): `33cd497b-bffd-404c-910e-f8dd1f4453bd`
+- Practice ($399): `9a5a7f48-0ffe-448a-a1af-889af99a0f47`
+- Personal ($49): not yet found in code, confirm/create.

--- a/website/blog/byok-actual-cost-after-60-days.html
+++ b/website/blog/byok-actual-cost-after-60-days.html
@@ -193,7 +193,7 @@
 
     <p>Use it for a month. Look at the actual bill. Adjust the cap up or down. After 60 days you'll know whether the math works for your usage pattern. There's no commitment beyond what you've already used.</p>
 
-    <a href="/#download" class="cta">Try BYOK with Keepance, $49 once</a>
+    <a href="/#pricing" class="cta">Try BYOK with Keepance, free for 30 days</a>
   </div>
 </body>
 </html>

--- a/website/blog/the-mcp-play-indie-tools-are-missing.html
+++ b/website/blog/the-mcp-play-indie-tools-are-missing.html
@@ -143,7 +143,7 @@
 
     <p>If you build an indie AI tool and you ship MCP support, drop me a note at <a href="mailto:support@keepance.com">support@keepance.com</a>. Happy to amplify and to compare implementation notes.</p>
 
-    <a href="/#download" class="cta">See how Keepance uses MCP, free download</a>
+    <a href="/#pricing" class="cta">See how Keepance uses MCP, free for 30 days</a>
   </div>
 </body>
 </html>

--- a/website/blog/why-i-built-keepance-on-markdown-not-a-database.html
+++ b/website/blog/why-i-built-keepance-on-markdown-not-a-database.html
@@ -189,7 +189,7 @@ CREATE TABLE messages (
 
     <p>For Keepance specifically, the answer was clearly "files." Eight weeks of building on that foundation has been smoother than I expected, and the claim ("your data is yours") is structurally true rather than aspirationally true. That distinction matters a lot if you're a practitioner with confidentiality obligations attached to what's in those files.</p>
 
-    <a href="/#download" class="cta">Try a Markdown-first AI workspace, free download</a>
+    <a href="/#pricing" class="cta">Try a Markdown-first AI workspace, free for 30 days</a>
   </div>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -516,7 +516,7 @@
           <div class="feature-text">
             <span class="section-label">No subscription</span>
             <h2>$129 once. Not $129 a month.</h2>
-            <p>Most AI tools charge monthly and hold your data as leverage. Keepance is a one-time purchase. The license is perpetual. Your files stay on your machine. If you stop using it tomorrow, every document is still exactly where you left it, in plain text, readable forever.</p>
+            <p>Most AI tools charge monthly and hold your data hostage to keep you paying. Keepance is a one-time purchase. The license is perpetual. Your files stay on your machine. If you stop using it tomorrow, every document is still exactly where you left it, in plain text, readable forever.</p>
             <ul class="feature-list">
               <li><span class="feature-list-check"><svg viewBox="0 0 12 12"><polyline points="2 6 5 9 10 3"/></svg></span>Perpetual license, one payment, owned forever</li>
               <li><span class="feature-list-check"><svg viewBox="0 0 12 12"><polyline points="2 6 5 9 10 3"/></svg></span>No per-query or per-token fees from Keepance</li>
@@ -596,10 +596,10 @@
           <div class="pricing-card">
             <div class="pricing-tier">Personal</div>
             <div class="pricing-price">$49</div>
-            <div class="pricing-price-note">one-time · all platforms</div>
+            <div class="pricing-price-note">one-time · general use, bring your own templates</div>
             <hr class="pricing-divider">
             <ul class="pricing-features">
-              <li class="strong">All core features</li>
+              <li class="strong">The full app, minus the profession packs</li>
               <li>Local-first AI workspace</li>
               <li>PDF chat &amp; document indexing</li>
               <li>Wiki-links, backlinks, full-text search</li>

--- a/website/local-first-ai-workspace/index.html
+++ b/website/local-first-ai-workspace/index.html
@@ -452,7 +452,7 @@
 
     <div class="cta-card">
       <h3>Try a local-first AI workspace</h3>
-      <p>Keepance is free to download. Your client files stay on your machine. Bring your own AI key. Sold once, no subscription.</p>
+      <p>Download Keepance free for 30 days. Your client files stay on your machine. Bring your own AI key. Sold once, no subscription.</p>
       <a href="/#pricing" class="cta-btn">Get Keepance</a>
     </div>
   </div>

--- a/website/local-first-vs-cloud-ai/index.html
+++ b/website/local-first-vs-cloud-ai/index.html
@@ -320,7 +320,7 @@
 
     <div class="cta-card">
       <h3>Try the local-first posture</h3>
-      <p>Keepance is free to download. Your client data stays on your machine. Bring your own AI key. Sold once, no subscription.</p>
+      <p>Download Keepance free for 30 days. Your client data stays on your machine. Bring your own AI key. Sold once, no subscription.</p>
       <a href="/#pricing" class="cta-btn">Get Keepance</a>
     </div>
   </div>

--- a/website/roadmap/index.html
+++ b/website/roadmap/index.html
@@ -694,7 +694,7 @@
     <div class="feature-banner-card">
       <h2>Try Keepance yourself</h2>
       <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
-      <a href="/#download" class="cta-btn">Get Keepance</a>
+      <a href="/#pricing" class="cta-btn">Download free for 30 days</a>
     </div>
   </div>
 

--- a/website/templates/_detail_template.html
+++ b/website/templates/_detail_template.html
@@ -130,7 +130,7 @@
 
     <div class="cta-card">
       <h3>Run this template on your own project</h3>
-      <p>Keepance is free to download. Every template runs against your own files, on your machine, with your own API key.</p>
+      <p>Download Keepance free for 30 days. Every template runs against your own files, on your machine, with your own API key.</p>
       <a href="/#pricing" class="cta-btn">Download Keepance</a>
     </div>
   </div>

--- a/website/vs/chatgpt.html
+++ b/website/vs/chatgpt.html
@@ -154,7 +154,7 @@
 
     <div class="cta-row">
       <p><strong>Want your chats as files, not tabs?</strong></p>
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a class="cta" href="/#pricing">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a>, <a href="/tax/">tax pros</a>, <a href="/consulting/">consultants</a>.</p>

--- a/website/vs/claude-projects.html
+++ b/website/vs/claude-projects.html
@@ -199,7 +199,7 @@
     </div>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a>, <a href="/tax/">tax pros</a>, <a href="/consulting/">consultants</a>.</p>

--- a/website/vs/cursor-for-writing.html
+++ b/website/vs/cursor-for-writing.html
@@ -159,7 +159,7 @@
     <p>Many professionals end up running both. The combined cost is comfortably under the standard subscription stack (Notion + ChatGPT + Linear + a few others) and replaces multiple tools.</p>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/heyday.html
+++ b/website/vs/heyday.html
@@ -149,7 +149,7 @@
     <p>If you're not regularly losing track of things you saw on screen, Heyday and Rewind are overkill. The 10-50 GB of storage and the privacy surface area aren't worth it for someone who just wants normal note-taking.</p>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/logseq.html
+++ b/website/vs/logseq.html
@@ -173,7 +173,7 @@
     <p>This is the easiest migration of any vs-page in this site, since the underlying file format is essentially the same. The biggest adjustment is the editor paradigm shift from outliner to paragraph editor.</p>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/mem-ai.html
+++ b/website/vs/mem-ai.html
@@ -198,7 +198,7 @@
     </div>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/notion.html
+++ b/website/vs/notion.html
@@ -137,7 +137,7 @@
     <ul>
       <li>You're an attorney, CPA, or consultant writing the client-facing documents that define your practice, not running a full team operations workspace.</li>
       <li>You want your files on your own hard drive in a format you can read with any editor.</li>
-      <li>You want to pay once (or zero) and never think about a subscription again.</li>
+      <li>You want to pay once and never think about a subscription again.</li>
       <li>You handle confidential client information and need to keep it off cloud infrastructure.</li>
       <li>You want AI with your own API key, paying your provider directly at inference cost.</li>
     </ul>
@@ -158,7 +158,7 @@
 
     <div class="cta-row">
       <p><strong>Want your client docs on your machine instead of Notion's?</strong></p>
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a class="cta" href="/#pricing">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/obsidian.html
+++ b/website/vs/obsidian.html
@@ -237,7 +237,7 @@
 
     <div class="cta-row">
       <p><strong>Ready to try the assembled version?</strong></p>
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a class="cta" href="/#pricing">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/reflect.html
+++ b/website/vs/reflect.html
@@ -196,7 +196,7 @@
     </div>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>

--- a/website/vs/tana.html
+++ b/website/vs/tana.html
@@ -152,7 +152,7 @@
     <p>The biggest adjustment: you lose the structured-query feature. If your Tana workflow depends heavily on supertag queries, Keepance will feel less expressive. If your Tana workflow is mostly outlining + AI assistance, the migration is straightforward and you'll barely notice.</p>
 
     <div class="cta-row">
-      <p>Download free for 30 days, no credit card. Personal $49, Professional $129 (includes one practice pack), Practice $399 (up to 5 seats). One-time purchase, no subscription.</p>
+      <p>Download free for 30 days, no credit card. Personal $49 (general use, bring your own templates), Professional $129 (adds your profession's practice pack), Practice $399 (up to 5 seats, all packs). One-time purchase, no subscription.</p>
       <a href="/#pricing" class="cta">Download free for 30 days</a>
       <p style="margin-top: 16px; font-size: 0.9375rem;">Founding offer: the first 100 buyers of each practice pack get Professional at $89 instead of $129. <a href="/#pricing">Reserve the founding price</a> while checkout opens.</p>
       <p style="margin-top: 12px; font-size: 0.9375rem;">Built for your field: <a href="/legal/">attorneys</a> and <a href="/consulting/">consultants</a>. See all: <a href="/">keepance.com</a> for attorneys, tax pros, and consultants.</p>


### PR DESCRIPTION
## What this is

Overnight sweep bringing **all** pricing and positioning copy in line with the live model, plus two canonical docs. Safe, reversible copy work only. No money/auth/deploy actions were taken (see "Deliberately NOT done" below).

## Pricing model this enforces (canonical)
Personal **$49** / Professional **$129** (the tier we sell, includes one pack) / Practice **$399** (5 seats), all one-time. **$89 charter** for first 100 per pack. **30-day trial**, no permanent free tier, no Lifetime.

## Changes

**Website copy (15 files)**
- All 10 `vs/*` pages: sharpened the price recap so Personal reads as the deliberate starter (*"general use, bring your own templates"*) vs Professional (*"adds your profession's practice pack"*). This is the fix for Personal cannibalizing Professional, positioning, not feature-crippling.
- `index.html`: Personal card differentiation; removed banned word "leverage".
- Fixed **dead `/#download` CTA anchors** and **"free download" / "free to download"** language (both implied the retired free tier) across 3 blog posts, 2 SEO landing pages, the roadmap, and the template scaffold. All now point to `/#pricing` with "free for 30 days" framing.
- `vs/notion.html`: dropped "pay once (or zero)" free-tier implication; pricing cells anchored on Professional $129 / ~$489 over 3y.

**Business plan**
- Rewrote Decision 2 to the post-pivot tiers; **corrected ARPU from ~$64 to ~$166**; replaced stale "Why $49 / free tier / Founder's Launch" reasoning with the $129-anchor + 30-day-trial + charter rationale; fixed launch checklist items.

**New docs**
- `docs/reference/PRICING_AND_POSITIONING.md`, canonical source of truth (tiers, charter, positioning, forbidden strings, voice rules, system-sync status with the known LemonSqueezy variant IDs).
- `docs/operations/LAUNCH_CHECKOUT_RUNBOOK.md`, step-by-step for the irreversible work to do together.

## Verification (all clean)
Forbidden Keepance pricing strings: 0. Sharpened recap: 10/10 vs pages. Banned vocab in rendered prose: 0. Em dashes in rendered prose: 0. ARPU corrected. Competitor facts (Obsidian free, Rewind $480 lifetime) correctly retained.

## ⚠️ Deliberately NOT done (needs you, awake)
1. **LemonSqueezy checkout + $89 charter** — real money/license issuance. Buy buttons remain commented-out TODOs (variant IDs are in the runbook).
2. **App license entitlement** (gate only the pack to Professional+) — real Tauri code, do test-first together.
3. **Deploy** — not run. **Also flagged a landmine:** `infra/deploy-keepance.sh` points at the near-empty `website-keepance/` and would `rsync --delete` it over the live site. Use `infra/deploy.sh` (→ `website/`) only; recommend deleting the bad script. Details in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)