### PR TITLE
Multi-provider email: provider seam + IMAP (reaches Gmail via app-password)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4411,6 +4411,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-stream",
+ "async-trait",
  "dirs 5.0.1",
  "fastembed",
  "flate2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -442,6 +442,17 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -450,6 +461,41 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-imap"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78dceaba06f029d8f4d7df20addd4b7370a30206e3926267ecda2915b0f3f66"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "imap-proto",
+ "log",
+ "nom 7.1.3",
+ "pin-project",
+ "pin-utils",
+ "self_cell",
+ "stop-token",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -1525,6 +1571,22 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -2870,6 +2932,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -4178,6 +4246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "imap-proto"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f6af35c6a517aea5c72314abe90134980d2ae6a763809b50c208b3e429d71f"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4499,7 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-schema",
+ "async-imap",
  "async-stream",
  "async-trait",
  "dirs 5.0.1",
@@ -4433,6 +4511,7 @@ dependencies = [
  "lancedb",
  "log",
  "mail-parser",
+ "native-tls",
  "notify",
  "rand 0.8.5",
  "reqwest",
@@ -4452,6 +4531,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tokio",
+ "tokio-native-tls",
  "walkdir",
  "wiremock",
 ]
@@ -4770,7 +4850,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
- "async-channel",
+ "async-channel 2.5.0",
  "async-recursion",
  "async-trait",
  "bitpacking",
@@ -7851,6 +7931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8348,6 +8434,18 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "stop-token"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
+dependencies = [
+ "async-channel 1.9.0",
+ "cfg-if",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "string_cache"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3697,6 +3697,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,6 +4432,7 @@ dependencies = [
  "keyring",
  "lancedb",
  "log",
+ "mail-parser",
  "notify",
  "rand 0.8.5",
  "reqwest",
@@ -5261,6 +5274,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "mail-parser"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
+dependencies = [
+ "hashify",
+]
 
 [[package]]
 name = "markup5ever"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,8 @@ hex = "0.4"
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
 aes-gcm = "0.10"
 rand = "0.8"
+# IMAP RFC822 normalizer — fast zero-copy email parser.
+mail-parser = "0.11"
 
 # Auto-updater. Desktop-only — Tauri mobile builds skip these targets so
 # the cfg() filter keeps the iOS/Android crate graph slim.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,8 +96,14 @@ hex = "0.4"
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
 aes-gcm = "0.10"
 rand = "0.8"
-# IMAP RFC822 normalizer — fast zero-copy email parser.
+# Mail import — RFC822 parser used by the IMAP normalizer.
 mail-parser = "0.11"
+# IMAP client (email/gmail-imap-multiprovider).
+# runtime-tokio enables the tokio AsyncRead/AsyncWrite impls; default-features=false
+# drops the async-std dep.  TLS is provided by tokio-native-tls + native-tls.
+async-imap = { version = "0.11.2", default-features = false, features = ["runtime-tokio"] }
+tokio-native-tls = "0.3"
+native-tls = "0.2"
 
 # Auto-updater. Desktop-only — Tauri mobile builds skip these targets so
 # the cfg() filter keeps the iOS/Android crate graph slim.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,6 +83,7 @@ async-stream = "0.3"
 # Ergonomic error contexts for the M1 RAG indexer (chunker / embedder /
 # store all use `?` against heterogeneous error types).
 anyhow = "1"
+async-trait = "0.1"
 # Stream B TTS — voice archive download and extraction.
 # Stream C1 (Templates Marketplace) — also reuses flate2 + tar for tarball
 # extraction and adds `hex` for the SHA-256 file checksum command.

--- a/src-tauri/src/commands/mail/graph.rs
+++ b/src-tauri/src/commands/mail/graph.rs
@@ -107,6 +107,79 @@ pub fn page_continuation(page: &serde_json::Value) -> Continuation {
     Continuation::End
 }
 
+use crate::commands::mail::model::MailMessage;
+use crate::commands::mail::provider::{ChangePage, Cursor, MailProvider, RemoteFolder};
+use async_trait::async_trait;
+
+/// Max consecutive 410 (delta-token-expired) resets within one fetch before giving up.
+const PROVIDER_MAX_DELTA_RESETS: u32 = 3;
+
+/// Microsoft 365 implementation of `MailProvider`, wrapping `GraphClient`.
+pub struct GraphProvider { client: GraphClient }
+impl GraphProvider {
+    pub fn new(token: String) -> Self { Self { client: GraphClient::new(token) } }
+    pub fn new_with_base(token: String, base: String) -> Self { Self { client: GraphClient::new_with_base(token, base) } }
+}
+
+#[async_trait]
+impl MailProvider for GraphProvider {
+    fn kind(&self) -> &'static str { "m365" }
+
+    async fn list_folders(&self) -> anyhow::Result<Vec<RemoteFolder>> {
+        let mut folders = Vec::new();
+        let mut next = Some(format!("{}/v1.0/me/mailFolders?$top=200", self.client.base()));
+        while let Some(url) = next {
+            let page = self.client.get_json(&url).await?;
+            if let Some(arr) = page.get("value").and_then(|v| v.as_array()) {
+                for f in arr {
+                    if let Some(id) = f.get("id").and_then(|s| s.as_str()) {
+                        let name = f.get("displayName").and_then(|s| s.as_str()).unwrap_or(id).to_string();
+                        folders.push(RemoteFolder { id: id.to_string(), display_name: name });
+                    }
+                }
+            }
+            next = page.get("@odata.nextLink").and_then(|v| v.as_str()).map(String::from);
+        }
+        Ok(folders)
+    }
+
+    async fn fetch_changes(&self, folder: &RemoteFolder, cursor: &Cursor) -> anyhow::Result<ChangePage> {
+        let mut url = match cursor {
+            Cursor::Backfill => self.client.delta_start_url(&folder.id),
+            Cursor::Resume(t) => t.clone(),
+        };
+        let mut resets = 0u32;
+        let page = loop {
+            match self.client.get_json(&url).await {
+                Ok(p) => break p,
+                Err(e) if e.downcast_ref::<DeltaGone>().is_some() => {
+                    resets += 1;
+                    if resets > PROVIDER_MAX_DELTA_RESETS {
+                        anyhow::bail!("folder {}: delta token expired {} times in a row; giving up", folder.id, resets);
+                    }
+                    url = self.client.delta_start_url(&folder.id);
+                }
+                Err(e) => return Err(e),
+            }
+        };
+        let mut messages = Vec::new();
+        let mut removed_ids = Vec::new();
+        if let Some(arr) = page.get("value").and_then(|v| v.as_array()) {
+            for item in arr {
+                let id = item.get("id").and_then(|s| s.as_str()).unwrap_or("");
+                if id.is_empty() { continue; }
+                if MailMessage::is_removed(item) { removed_ids.push(id.to_string()); }
+                else if let Some(m) = MailMessage::from_graph(item) { messages.push(m); }
+            }
+        }
+        Ok(match page_continuation(&page) {
+            Continuation::Next(n) => ChangePage { messages, removed_ids, next: Some(n), done: false },
+            Continuation::Delta(d) => ChangePage { messages, removed_ids, next: Some(d), done: true },
+            Continuation::End => ChangePage { messages, removed_ids, next: None, done: true },
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,5 +265,30 @@ mod tests {
             err.downcast_ref::<DeltaGone>().is_some(),
             "expected DeltaGone sentinel, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn graph_provider_fetch_changes_backfill_returns_message_and_delta_done() {
+        use crate::commands::mail::provider::{Cursor, RemoteFolder};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::matchers::{method, path};
+
+        let server = MockServer::start().await;
+        let delta_link = format!("{}/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=tok123", server.uri());
+        Mock::given(method("GET")).and(path("/v1.0/me/mailFolders/inbox/messages/delta"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [{ "id": "msg1", "subject": "Hello from Graph", "body": { "contentType": "text", "content": "Body text here." } }],
+                "@odata.deltaLink": delta_link
+            }))).mount(&server).await;
+
+        let provider = GraphProvider::new_with_base("AT".into(), server.uri());
+        let folder = RemoteFolder { id: "inbox".into(), display_name: "Inbox".into() };
+        let page = provider.fetch_changes(&folder, &Cursor::Backfill).await.expect("fetch_changes");
+
+        assert_eq!(page.messages.len(), 1, "expected exactly one message");
+        assert_eq!(page.messages[0].id, "msg1");
+        assert!(page.done, "Cursor::Backfill with deltaLink must be done=true");
+        assert_eq!(page.next, Some(delta_link), "next must equal the deltaLink");
+        assert!(page.removed_ids.is_empty(), "no tombstones expected");
     }
 }

--- a/src-tauri/src/commands/mail/imap/client.rs
+++ b/src-tauri/src/commands/mail/imap/client.rs
@@ -3,6 +3,11 @@
 //! Provides async helpers to open a TLS IMAP session (imaps, port 993),
 //! list folders, select a mailbox, and UID-fetch a range of messages.
 //!
+//! Every network operation is bounded by a timeout so a stalled server (slow
+//! TLS handshake, no LOGIN response, mid-fetch hang) can never block the sync
+//! task indefinitely (which would hold the `is_syncing` guard until an app
+//! restart). Mirrors the timeouts the Graph HTTP client already sets.
+//!
 //! These functions touch the network and are intentionally NOT unit-tested.
 //! Live coverage is exercised by the manual #[ignore]d smoke test described
 //! in `imap/mod.rs`.
@@ -12,7 +17,15 @@ use async_imap::types::Name;
 use futures_util::TryStreamExt;
 use native_tls::TlsConnector;
 use tokio::net::TcpStream;
+use tokio::time::{timeout, Duration};
 use tokio_native_tls::TlsStream;
+
+/// Bound for establishing the connection (TCP + TLS + greeting + LOGIN).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bound for a lightweight command (SELECT, LIST).
+const CMD_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bound for a UID FETCH batch (can transfer up to a few hundred messages).
+const FETCH_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// An authenticated IMAP session over TLS.
 pub type ImapSession = async_imap::Session<TlsStream<TcpStream>>;
@@ -20,7 +33,19 @@ pub type ImapSession = async_imap::Session<TlsStream<TcpStream>>;
 /// Open a TLS IMAP connection (imaps) and log in with the supplied credentials.
 ///
 /// On success returns an authenticated [`ImapSession`] ready for IMAP commands.
+/// The whole connect + handshake + login sequence is bounded by [`CONNECT_TIMEOUT`].
 pub async fn connect(
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<ImapSession> {
+    timeout(CONNECT_TIMEOUT, connect_inner(host, port, username, password))
+        .await
+        .map_err(|_| anyhow::anyhow!("IMAP connect to {host}:{port} timed out"))?
+}
+
+async fn connect_inner(
     host: &str,
     port: u16,
     username: &str,
@@ -41,10 +66,9 @@ pub async fn connect(
         .with_context(|| format!("IMAP TLS handshake with {host}"))?;
 
     // Build an async-imap client over the TLS stream.
-    let client = async_imap::Client::new(tls_stream);
+    let mut client = async_imap::Client::new(tls_stream);
 
     // Read the server greeting before issuing LOGIN.
-    let mut client = client;
     client
         .read_response()
         .await
@@ -52,7 +76,8 @@ pub async fn connect(
         .ok_or_else(|| anyhow::anyhow!("IMAP server closed connection before greeting"))?;
 
     // Authenticate (login returns the error alongside the client so the caller
-    // can retry; we just surface the error here).
+    // can retry; we just surface the error here). The error enum never contains
+    // the password.
     let session = client
         .login(username, password)
         .await
@@ -77,9 +102,9 @@ pub async fn select_mailbox(
     session: &mut ImapSession,
     mailbox_name: &str,
 ) -> anyhow::Result<MailboxInfo> {
-    let mbox = session
-        .select(mailbox_name)
+    let mbox = timeout(CMD_TIMEOUT, session.select(mailbox_name))
         .await
+        .map_err(|_| anyhow::anyhow!("IMAP SELECT {mailbox_name} timed out"))?
         .with_context(|| format!("IMAP SELECT {mailbox_name}"))?;
 
     let uid_validity = mbox
@@ -97,15 +122,17 @@ pub async fn select_mailbox(
 
 /// LIST all mailboxes and return their names.
 pub async fn list_mailboxes(session: &mut ImapSession) -> anyhow::Result<Vec<String>> {
-    let names_stream = session
-        .list(Some(""), Some("*"))
+    let collect = async {
+        let names_stream = session.list(Some(""), Some("*")).await.context("IMAP LIST")?;
+        let names: Vec<Name> = names_stream
+            .try_collect()
+            .await
+            .context("collect IMAP LIST response")?;
+        Ok::<Vec<Name>, anyhow::Error>(names)
+    };
+    let names = timeout(CMD_TIMEOUT, collect)
         .await
-        .context("IMAP LIST")?;
-
-    let names: Vec<Name> = names_stream
-        .try_collect()
-        .await
-        .context("collect IMAP LIST response")?;
+        .map_err(|_| anyhow::anyhow!("IMAP LIST timed out"))??;
 
     Ok(names.iter().map(|n| n.name().to_string()).collect())
 }
@@ -123,15 +150,20 @@ pub async fn uid_fetch_range(
     let uid_set = format!("{first_uid}:{last_uid}");
 
     // BODY.PEEK[] fetches the complete RFC822 message without marking \Seen.
-    let fetch_stream = session
-        .uid_fetch(&uid_set, "BODY.PEEK[]")
+    let collect = async {
+        let fetch_stream = session
+            .uid_fetch(&uid_set, "BODY.PEEK[]")
+            .await
+            .with_context(|| format!("UID FETCH {uid_set}"))?;
+        let fetches: Vec<_> = fetch_stream
+            .try_collect()
+            .await
+            .with_context(|| format!("collect UID FETCH {uid_set}"))?;
+        Ok::<Vec<_>, anyhow::Error>(fetches)
+    };
+    let fetches = timeout(FETCH_TIMEOUT, collect)
         .await
-        .with_context(|| format!("UID FETCH {uid_set}"))?;
-
-    let fetches: Vec<_> = fetch_stream
-        .try_collect()
-        .await
-        .with_context(|| format!("collect UID FETCH {uid_set}"))?;
+        .map_err(|_| anyhow::anyhow!("UID FETCH {uid_set} timed out"))??;
 
     let mut results = Vec::with_capacity(fetches.len());
     for fetch in &fetches {

--- a/src-tauri/src/commands/mail/imap/client.rs
+++ b/src-tauri/src/commands/mail/imap/client.rs
@@ -1,0 +1,150 @@
+//! Thin IMAP connection wrapper.
+//!
+//! Provides async helpers to open a TLS IMAP session (imaps, port 993),
+//! list folders, select a mailbox, and UID-fetch a range of messages.
+//!
+//! These functions touch the network and are intentionally NOT unit-tested.
+//! Live coverage is exercised by the manual #[ignore]d smoke test described
+//! in `imap/mod.rs`.
+
+use anyhow::Context as _;
+use async_imap::types::Name;
+use futures_util::TryStreamExt;
+use native_tls::TlsConnector;
+use tokio::net::TcpStream;
+use tokio_native_tls::TlsStream;
+
+/// An authenticated IMAP session over TLS.
+pub type ImapSession = async_imap::Session<TlsStream<TcpStream>>;
+
+/// Open a TLS IMAP connection (imaps) and log in with the supplied credentials.
+///
+/// On success returns an authenticated [`ImapSession`] ready for IMAP commands.
+pub async fn connect(
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<ImapSession> {
+    // Establish TCP then wrap in TLS.
+    let tcp = TcpStream::connect((host, port))
+        .await
+        .with_context(|| format!("IMAP TCP connect to {host}:{port}"))?;
+
+    let tls = TlsConnector::builder()
+        .build()
+        .context("build TLS connector")?;
+    let tls = tokio_native_tls::TlsConnector::from(tls);
+    let tls_stream = tls
+        .connect(host, tcp)
+        .await
+        .with_context(|| format!("IMAP TLS handshake with {host}"))?;
+
+    // Build an async-imap client over the TLS stream.
+    let client = async_imap::Client::new(tls_stream);
+
+    // Read the server greeting before issuing LOGIN.
+    let mut client = client;
+    client
+        .read_response()
+        .await
+        .context("read IMAP greeting")?
+        .ok_or_else(|| anyhow::anyhow!("IMAP server closed connection before greeting"))?;
+
+    // Authenticate (login returns the error alongside the client so the caller
+    // can retry; we just surface the error here).
+    let session = client
+        .login(username, password)
+        .await
+        .map_err(|(e, _client)| anyhow::anyhow!("IMAP LOGIN failed: {e}"))?;
+
+    Ok(session)
+}
+
+/// UIDVALIDITY and UIDNEXT as returned by SELECT.
+#[derive(Debug, Clone, Copy)]
+pub struct MailboxInfo {
+    pub uid_validity: u32,
+    /// Next UID that will be assigned.  A new message arrives iff UID < uid_next.
+    pub uid_next: u32,
+}
+
+/// Select `mailbox_name` and return its UIDVALIDITY + UIDNEXT.
+///
+/// Returns an error if the server does not report both values (required by
+/// RFC 3501 §2.3.1).
+pub async fn select_mailbox(
+    session: &mut ImapSession,
+    mailbox_name: &str,
+) -> anyhow::Result<MailboxInfo> {
+    let mbox = session
+        .select(mailbox_name)
+        .await
+        .with_context(|| format!("IMAP SELECT {mailbox_name}"))?;
+
+    let uid_validity = mbox
+        .uid_validity
+        .ok_or_else(|| anyhow::anyhow!("server did not report UIDVALIDITY for {mailbox_name}"))?;
+    let uid_next = mbox
+        .uid_next
+        .ok_or_else(|| anyhow::anyhow!("server did not report UIDNEXT for {mailbox_name}"))?;
+
+    Ok(MailboxInfo {
+        uid_validity,
+        uid_next,
+    })
+}
+
+/// LIST all mailboxes and return their names.
+pub async fn list_mailboxes(session: &mut ImapSession) -> anyhow::Result<Vec<String>> {
+    let names_stream = session
+        .list(Some(""), Some("*"))
+        .await
+        .context("IMAP LIST")?;
+
+    let names: Vec<Name> = names_stream
+        .try_collect()
+        .await
+        .context("collect IMAP LIST response")?;
+
+    Ok(names.iter().map(|n| n.name().to_string()).collect())
+}
+
+/// UID-FETCH a contiguous inclusive range `[first_uid, last_uid]` using
+/// `BODY.PEEK[]` (never sets the `\Seen` flag).
+///
+/// Returns `(uid, raw_rfc822_bytes)` pairs for messages that have a body.
+/// Messages with no body in the response are silently skipped.
+pub async fn uid_fetch_range(
+    session: &mut ImapSession,
+    first_uid: u32,
+    last_uid: u32,
+) -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+    let uid_set = format!("{first_uid}:{last_uid}");
+
+    // BODY.PEEK[] fetches the complete RFC822 message without marking \Seen.
+    let fetch_stream = session
+        .uid_fetch(&uid_set, "BODY.PEEK[]")
+        .await
+        .with_context(|| format!("UID FETCH {uid_set}"))?;
+
+    let fetches: Vec<_> = fetch_stream
+        .try_collect()
+        .await
+        .with_context(|| format!("collect UID FETCH {uid_set}"))?;
+
+    let mut results = Vec::with_capacity(fetches.len());
+    for fetch in &fetches {
+        let uid = match fetch.uid {
+            Some(u) => u,
+            None => continue, // no UID in response; skip
+        };
+        let raw = match fetch.body() {
+            Some(b) => b.to_vec(),
+            None => continue, // server returned no body section; skip
+        };
+        results.push((uid, raw));
+    }
+
+    Ok(results)
+}

--- a/src-tauri/src/commands/mail/imap/mod.rs
+++ b/src-tauri/src/commands/mail/imap/mod.rs
@@ -1,0 +1,1 @@
+pub mod normalize;

--- a/src-tauri/src/commands/mail/imap/mod.rs
+++ b/src-tauri/src/commands/mail/imap/mod.rs
@@ -39,6 +39,35 @@ pub fn format_cursor(uidvalidity: u32, last_uid: u32) -> String {
     format!("{uidvalidity}:{last_uid}")
 }
 
+/// Compute the next UID batch to fetch, or `None` if already caught up.
+///
+/// Returns `(first_uid, last_uid_inclusive, done)`. A UIDVALIDITY change (or a
+/// stored validity of 0) resets to a full backfill from UID 1. `done` is true
+/// when the batch reaches the highest existing UID (`uid_next - 1`).
+///
+/// The caller MUST advance the stored cursor to `last_uid_inclusive` (the end of
+/// the processed range), NOT merely to the highest UID that returned a body.
+/// `uid_fetch_range` collects the complete server response, so any UID in the
+/// range that returned no body is expunged/unfetchable; advancing past it
+/// guarantees forward progress and prevents an unbounded paging loop when a
+/// whole batch yields nothing.
+pub fn compute_batch_range(
+    stored_uidvalidity: u32,
+    last_uid: u32,
+    current_uidvalidity: u32,
+    uid_next: u32,
+) -> Option<(u32, u32, bool)> {
+    let effective_last = if stored_uidvalidity != current_uidvalidity { 0 } else { last_uid };
+    let first = effective_last.saturating_add(1);
+    let highest_existing = uid_next.saturating_sub(1);
+    if first > highest_existing {
+        return None; // caught up (also covers an empty mailbox)
+    }
+    let last = first.saturating_add(BATCH - 1).min(highest_existing);
+    let done = last >= highest_existing;
+    Some((first, last, done))
+}
+
 // ─────────────────────────────────────────────────────────
 // ImapProvider
 // ─────────────────────────────────────────────────────────
@@ -89,7 +118,7 @@ impl MailProvider for ImapProvider {
         cursor: &Cursor,
     ) -> anyhow::Result<ChangePage> {
         // ── Decode the stored cursor ──────────────────────────────────────
-        let (stored_uidvalidity, mut last_uid) = match cursor {
+        let (stored_uidvalidity, last_uid) = match cursor {
             Cursor::Backfill => (0u32, 0u32),
             Cursor::Resume(s) => parse_cursor(s),
         };
@@ -104,36 +133,24 @@ impl MailProvider for ImapProvider {
             .context("ImapProvider::fetch_changes: SELECT")?;
 
         let current_uidvalidity = info.uid_validity;
-        let uid_next = info.uid_next;
 
-        // ── Detect UIDVALIDITY change (re-backfill) ───────────────────────
-        if stored_uidvalidity != current_uidvalidity {
-            // Mailbox was recreated or this is first sync.  Start from the top.
-            last_uid = 0;
-        }
-
-        // ── Compute fetch range ───────────────────────────────────────────
-        // Fetch UIDs in (last_uid+1 ..= uid_next-1), capped to BATCH.
-        // uid_next is the *next to be assigned*, so the highest existing UID is
-        // uid_next - 1.  If uid_next == 0 (empty box) or last_uid >= uid_next-1
-        // there is nothing to fetch.
-        let first_new = last_uid.saturating_add(1);
-        let highest_existing = uid_next.saturating_sub(1);
-
-        if first_new > highest_existing {
-            // Already caught up.
-            let _ = session.logout().await;
-            return Ok(ChangePage {
-                messages: vec![],
-                removed_ids: vec![],
-                next: Some(format_cursor(current_uidvalidity, last_uid)),
-                done: true,
-            });
-        }
-
-        // Fetch at most BATCH messages at a time (lowest UIDs first).
-        let batch_last = (first_new + BATCH - 1).min(highest_existing);
-        let done = batch_last >= highest_existing;
+        // ── Compute the next UID batch (handles UIDVALIDITY reset + paging) ─
+        let (first_new, batch_last, done) =
+            match compute_batch_range(stored_uidvalidity, last_uid, current_uidvalidity, info.uid_next) {
+                Some(range) => range,
+                None => {
+                    // Already caught up. Record the current validity so a future
+                    // sync does not re-detect a "change" against a stale 0.
+                    let resume = if stored_uidvalidity != current_uidvalidity { 0 } else { last_uid };
+                    let _ = session.logout().await;
+                    return Ok(ChangePage {
+                        messages: vec![],
+                        removed_ids: vec![],
+                        next: Some(format_cursor(current_uidvalidity, resume)),
+                        done: true,
+                    });
+                }
+            };
 
         // ── UID FETCH ─────────────────────────────────────────────────────
         let raw_pairs = uid_fetch_range(&mut session, first_new, batch_last)
@@ -142,32 +159,24 @@ impl MailProvider for ImapProvider {
 
         let _ = session.logout().await; // best-effort
 
-        // Track the highest UID we actually received so the cursor advances
-        // only as far as confirmed data.
-        let mut highest_fetched = last_uid;
         let mut messages = Vec::with_capacity(raw_pairs.len());
-
         for (uid, raw) in raw_pairs {
             // Stable, account+folder-scoped message id.
-            let id = format!(
-                "imap:{}:{}:{}",
-                self.account, current_uidvalidity, uid
-            );
+            let id = format!("imap:{}:{}:{}", self.account, current_uidvalidity, uid);
             if let Some(msg) = from_rfc822(&id, &self.account, &folder.id, &raw) {
                 messages.push(msg);
-            }
-            if uid > highest_fetched {
-                highest_fetched = uid;
             }
         }
 
         // TODO(phase-2): UID-diff to detect server-side deletions.
         let removed_ids: Vec<String> = vec![];
 
+        // Advance the cursor to the END of the processed range (not just the
+        // highest UID with a body) so paging always makes forward progress.
         Ok(ChangePage {
             messages,
             removed_ids,
-            next: Some(format_cursor(current_uidvalidity, highest_fetched)),
+            next: Some(format_cursor(current_uidvalidity, batch_last)),
             done,
         })
     }
@@ -221,5 +230,51 @@ mod tests {
         // so parse_cursor returns the safe default (0, 0).
         // Real cursors are always two-field "UIDVALIDITY:LASTUID".
         assert_eq!(parse_cursor("10:20:30"), (0, 0));
+    }
+
+    // ── compute_batch_range ────────────────────────────────────────────────
+
+    #[test]
+    fn batch_backfill_small_box_done_in_one_page() {
+        // validity 0 stored => backfill; uid_next 5 => highest existing UID is 4.
+        assert_eq!(compute_batch_range(0, 0, 42, 5), Some((1, 4, true)));
+    }
+
+    #[test]
+    fn batch_resume_mid_box() {
+        assert_eq!(compute_batch_range(42, 2, 42, 5), Some((3, 4, true)));
+    }
+
+    #[test]
+    fn batch_caught_up_returns_none() {
+        assert_eq!(compute_batch_range(42, 4, 42, 5), None);
+    }
+
+    #[test]
+    fn batch_empty_mailbox_returns_none() {
+        // uid_next 1 => no messages yet.
+        assert_eq!(compute_batch_range(0, 0, 42, 1), None);
+    }
+
+    #[test]
+    fn batch_uidvalidity_change_forces_full_backfill() {
+        // stored validity 41 != current 42 => last_uid reset to 0, refetch from 1.
+        assert_eq!(compute_batch_range(41, 100, 42, 5), Some((1, 4, true)));
+    }
+
+    #[test]
+    fn batch_paging_advances_and_terminates() {
+        // 999 existing UIDs, BATCH=200: pages must cover 1..=999 and only the
+        // final page is done. Crucially `first` strictly increases each call,
+        // so paging always terminates (no unbounded loop).
+        let page1 = compute_batch_range(1, 0, 1, 1000).unwrap();
+        assert_eq!(page1, (1, 200, false));
+        let page2 = compute_batch_range(1, page1.1, 1, 1000).unwrap();
+        assert_eq!(page2, (201, 400, false));
+        // ... last page
+        let last = compute_batch_range(1, 800, 1, 1000).unwrap();
+        assert_eq!(last, (801, 999, true));
+        // After the last page the cursor is 999 => caught up.
+        assert_eq!(compute_batch_range(1, 999, 1, 1000), None);
     }
 }

--- a/src-tauri/src/commands/mail/imap/mod.rs
+++ b/src-tauri/src/commands/mail/imap/mod.rs
@@ -1,1 +1,225 @@
+pub mod client;
 pub mod normalize;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+
+use crate::commands::mail::provider::{ChangePage, Cursor, MailProvider, RemoteFolder};
+
+use self::client::{connect, list_mailboxes, select_mailbox, uid_fetch_range};
+use self::normalize::from_rfc822;
+
+// ─────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────
+
+/// Maximum messages fetched per `fetch_changes` call.
+const BATCH: u32 = 200;
+
+// ─────────────────────────────────────────────────────────
+// Pure cursor helpers (unit-tested; no network required)
+// ─────────────────────────────────────────────────────────
+
+/// Parse a resume cursor string of the form `"UIDVALIDITY:LASTUID"`.
+///
+/// Returns `(0, 0)` for any malformed or empty input so that callers treat
+/// unexpected tokens as a fresh backfill rather than panicking.
+pub fn parse_cursor(s: &str) -> (u32, u32) {
+    let mut parts = s.splitn(2, ':');
+    let v = parts.next().and_then(|p| p.parse::<u32>().ok());
+    let u = parts.next().and_then(|p| p.parse::<u32>().ok());
+    match (v, u) {
+        (Some(v), Some(u)) => (v, u),
+        _ => (0, 0),
+    }
+}
+
+/// Format a resume cursor string from `(uidvalidity, last_uid)`.
+pub fn format_cursor(uidvalidity: u32, last_uid: u32) -> String {
+    format!("{uidvalidity}:{last_uid}")
+}
+
+// ─────────────────────────────────────────────────────────
+// ImapProvider
+// ─────────────────────────────────────────────────────────
+
+/// IMAP implementation of [`MailProvider`] using UID-based incremental sync.
+///
+/// Each `fetch_changes` call opens a fresh authenticated connection, performs
+/// one SELECT, fetches up to [`BATCH`] new messages, and closes the session.
+/// Connection reuse across calls is left for a future optimisation pass.
+pub struct ImapProvider {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    /// Display name / key used in stable message ids (e.g. the user's email address).
+    pub account: String,
+}
+
+#[async_trait]
+impl MailProvider for ImapProvider {
+    fn kind(&self) -> &'static str {
+        "imap"
+    }
+
+    async fn list_folders(&self) -> anyhow::Result<Vec<RemoteFolder>> {
+        let mut session = connect(&self.host, self.port, &self.username, &self.password)
+            .await
+            .context("ImapProvider::list_folders: connect")?;
+
+        let names = list_mailboxes(&mut session)
+            .await
+            .context("ImapProvider::list_folders: LIST")?;
+
+        let _ = session.logout().await; // best-effort; ignore errors
+
+        Ok(names
+            .into_iter()
+            .map(|n| RemoteFolder {
+                id: n.clone(),
+                display_name: n,
+            })
+            .collect())
+    }
+
+    async fn fetch_changes(
+        &self,
+        folder: &RemoteFolder,
+        cursor: &Cursor,
+    ) -> anyhow::Result<ChangePage> {
+        // ── Decode the stored cursor ──────────────────────────────────────
+        let (stored_uidvalidity, mut last_uid) = match cursor {
+            Cursor::Backfill => (0u32, 0u32),
+            Cursor::Resume(s) => parse_cursor(s),
+        };
+
+        // ── Connect and SELECT ────────────────────────────────────────────
+        let mut session = connect(&self.host, self.port, &self.username, &self.password)
+            .await
+            .context("ImapProvider::fetch_changes: connect")?;
+
+        let info = select_mailbox(&mut session, &folder.id)
+            .await
+            .context("ImapProvider::fetch_changes: SELECT")?;
+
+        let current_uidvalidity = info.uid_validity;
+        let uid_next = info.uid_next;
+
+        // ── Detect UIDVALIDITY change (re-backfill) ───────────────────────
+        if stored_uidvalidity != current_uidvalidity {
+            // Mailbox was recreated or this is first sync.  Start from the top.
+            last_uid = 0;
+        }
+
+        // ── Compute fetch range ───────────────────────────────────────────
+        // Fetch UIDs in (last_uid+1 ..= uid_next-1), capped to BATCH.
+        // uid_next is the *next to be assigned*, so the highest existing UID is
+        // uid_next - 1.  If uid_next == 0 (empty box) or last_uid >= uid_next-1
+        // there is nothing to fetch.
+        let first_new = last_uid.saturating_add(1);
+        let highest_existing = uid_next.saturating_sub(1);
+
+        if first_new > highest_existing {
+            // Already caught up.
+            let _ = session.logout().await;
+            return Ok(ChangePage {
+                messages: vec![],
+                removed_ids: vec![],
+                next: Some(format_cursor(current_uidvalidity, last_uid)),
+                done: true,
+            });
+        }
+
+        // Fetch at most BATCH messages at a time (lowest UIDs first).
+        let batch_last = (first_new + BATCH - 1).min(highest_existing);
+        let done = batch_last >= highest_existing;
+
+        // ── UID FETCH ─────────────────────────────────────────────────────
+        let raw_pairs = uid_fetch_range(&mut session, first_new, batch_last)
+            .await
+            .context("ImapProvider::fetch_changes: UID FETCH")?;
+
+        let _ = session.logout().await; // best-effort
+
+        // Track the highest UID we actually received so the cursor advances
+        // only as far as confirmed data.
+        let mut highest_fetched = last_uid;
+        let mut messages = Vec::with_capacity(raw_pairs.len());
+
+        for (uid, raw) in raw_pairs {
+            // Stable, account+folder-scoped message id.
+            let id = format!(
+                "imap:{}:{}:{}",
+                self.account, current_uidvalidity, uid
+            );
+            if let Some(msg) = from_rfc822(&id, &self.account, &folder.id, &raw) {
+                messages.push(msg);
+            }
+            if uid > highest_fetched {
+                highest_fetched = uid;
+            }
+        }
+
+        // TODO(phase-2): UID-diff to detect server-side deletions.
+        let removed_ids: Vec<String> = vec![];
+
+        Ok(ChangePage {
+            messages,
+            removed_ids,
+            next: Some(format_cursor(current_uidvalidity, highest_fetched)),
+            done,
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// Unit tests — pure helpers only (no network)
+// ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // live IMAP coverage is exercised by a manual #[ignore]d test added in a later task
+
+    #[test]
+    fn cursor_roundtrips() {
+        assert_eq!(parse_cursor(&format_cursor(42, 1000)), (42, 1000));
+    }
+
+    #[test]
+    fn cursor_parse_handles_garbage() {
+        assert_eq!(parse_cursor(""), (0, 0));
+        assert_eq!(parse_cursor("nonsense"), (0, 0));
+        assert_eq!(parse_cursor("42"), (0, 0)); // missing second field -> default
+        assert_eq!(parse_cursor("42:1000"), (42, 1000));
+    }
+
+    #[test]
+    fn cursor_zero_roundtrips() {
+        assert_eq!(parse_cursor(&format_cursor(0, 0)), (0, 0));
+    }
+
+    #[test]
+    fn cursor_max_u32_roundtrips() {
+        assert_eq!(
+            parse_cursor(&format_cursor(u32::MAX, u32::MAX)),
+            (u32::MAX, u32::MAX)
+        );
+    }
+
+    #[test]
+    fn format_cursor_produces_colon_separated_string() {
+        assert_eq!(format_cursor(99, 5), "99:5");
+        assert_eq!(format_cursor(1, 0), "1:0");
+    }
+
+    #[test]
+    fn parse_cursor_three_colons_returns_default() {
+        // "10:20:30" — second token is "20:30" which is not a valid u32,
+        // so parse_cursor returns the safe default (0, 0).
+        // Real cursors are always two-field "UIDVALIDITY:LASTUID".
+        assert_eq!(parse_cursor("10:20:30"), (0, 0));
+    }
+}

--- a/src-tauri/src/commands/mail/imap/normalize.rs
+++ b/src-tauri/src/commands/mail/imap/normalize.rs
@@ -1,0 +1,216 @@
+use mail_parser::{Address, HeaderValue, MessageParser};
+
+use crate::commands::mail::model::{BodyContentType, MailMessage, Recipient};
+
+/// Convert an `Address` (List or Group) into a `Vec<Recipient>`.
+fn addr_to_recipients(addr: &Address<'_>) -> Vec<Recipient> {
+    addr.iter()
+        .map(|a| Recipient {
+            name: a.name().map(String::from),
+            address: a.address().map(String::from),
+        })
+        .collect()
+}
+
+/// Strip surrounding `<>` from a message-id string.
+/// mail-parser 0.11 already strips them via `parse_id`, but this is a no-op
+/// safety guard if a caller ever passes a raw value.
+fn strip_angle_brackets(s: &str) -> &str {
+    s.strip_prefix('<')
+        .and_then(|s| s.strip_suffix('>'))
+        .unwrap_or(s)
+}
+
+/// Parse a raw RFC822 message into a normalized [`MailMessage`].
+///
+/// `id` is the stable id the caller assigns (the IMAP provider derives it from
+/// UID/UIDVALIDITY or the Message-ID). `account` and `mailbox` are provenance.
+///
+/// Returns `None` only if `MessageParser::parse` fails outright (i.e. the bytes
+/// are not a recognisable RFC822 message at all).
+pub fn from_rfc822(id: &str, account: &str, mailbox: &str, raw: &[u8]) -> Option<MailMessage> {
+    let msg = MessageParser::default().parse(raw)?;
+
+    // Subject
+    let subject = msg.subject().unwrap_or("").to_string();
+
+    // From
+    let (from_name, from_address) = msg
+        .from()
+        .and_then(|a| a.first())
+        .map(|addr| {
+            (
+                addr.name().map(String::from),
+                addr.address().map(String::from),
+            )
+        })
+        .unwrap_or((None, None));
+
+    // To / Cc
+    let to = msg
+        .to()
+        .map(|a| addr_to_recipients(a))
+        .unwrap_or_default();
+    let cc = msg
+        .cc()
+        .map(|a| addr_to_recipients(a))
+        .unwrap_or_default();
+
+    // Message-ID (mail-parser 0.11 already strips the surrounding <>)
+    let internet_message_id = msg
+        .message_id()
+        .map(|s| strip_angle_brackets(s).to_string());
+
+    // Date as RFC3339 string
+    let received_date_time = msg.date().map(|dt| dt.to_rfc3339());
+
+    // Thread-ID: first Reference > In-Reply-To > own Message-ID
+    let thread_id = {
+        // references() returns &HeaderValue — TextList for multiple IDs, Text
+        // for a single one; ids are already stripped of <> by parse_id.
+        let from_refs = match msg.references() {
+            HeaderValue::TextList(list) => list.first().map(|s| s.as_ref().to_string()),
+            HeaderValue::Text(s) => Some(strip_angle_brackets(s.as_ref()).to_string()),
+            _ => None,
+        };
+        let from_irt = match msg.in_reply_to() {
+            HeaderValue::TextList(list) => list.first().map(|s| s.as_ref().to_string()),
+            HeaderValue::Text(s) => Some(strip_angle_brackets(s.as_ref()).to_string()),
+            _ => None,
+        };
+        from_refs
+            .or(from_irt)
+            .or_else(|| internet_message_id.clone())
+    };
+
+    // Body: prefer text/plain; fall back to HTML.
+    //
+    // mail-parser 0.11 adds an HTML-only single-part message to both
+    // `text_body` and `html_body` (the part type inside is `PartType::Html`).
+    // We therefore check the actual PartType of the first text_body entry:
+    //   - PartType::Text  → plain text, use body_text(0)
+    //   - PartType::Html  → HTML-only message in the text_body list;
+    //                       surface the raw HTML with BodyContentType::Html
+    // If text_body is empty but html_body is not, same HTML path applies.
+    let (body_text, body_content_type) = if msg.text_body_count() > 0 {
+        // Inspect the first text_body part's actual PartType.
+        let first_part = msg
+            .text_part(0)
+            .map(|p| matches!(p.body, mail_parser::PartType::Html(_)))
+            .unwrap_or(false);
+        if first_part {
+            // The "text" slot holds raw HTML — treat it as HTML.
+            let html = msg
+                .text_part(0)
+                .and_then(|p| {
+                    if let mail_parser::PartType::Html(h) = &p.body {
+                        Some(h.as_ref().to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default();
+            (html, BodyContentType::Html)
+        } else {
+            let text = msg.body_text(0).map(|s| s.into_owned()).unwrap_or_default();
+            (text, BodyContentType::Text)
+        }
+    } else if msg.html_body_count() > 0 {
+        // No text_body at all — take first HTML part raw.
+        let html = msg
+            .html_bodies()
+            .next()
+            .and_then(|p| {
+                if let mail_parser::PartType::Html(h) = &p.body {
+                    Some(h.as_ref().to_string())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        (html, BodyContentType::Html)
+    } else {
+        (String::new(), BodyContentType::Text)
+    };
+
+    // Attachments
+    let has_attachments = msg.attachment_count() > 0;
+
+    Some(MailMessage {
+        id: id.to_string(),
+        conversation_id: None,
+        internet_message_id,
+        subject,
+        received_date_time,
+        from_name,
+        from_address,
+        to,
+        cc,
+        has_attachments,
+        body_content_type,
+        body_text,
+        folders: vec![mailbox.to_string()],
+        thread_id,
+        provider: "imap".to_string(),
+        account: account.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RAW: &[u8] = b"From: Pat H <pat@hender.com>\r\nTo: Me <me@firm.com>\r\nSubject: Closing date\r\nMessage-ID: <abc@hender.com>\r\nReferences: <root@hender.com> <abc@hender.com>\r\nDate: Fri, 01 May 2026 14:30:00 +0000\r\n\r\nConfirming May 14.\r\n";
+
+    #[test]
+    fn parses_core_headers_and_body() {
+        let m = from_rfc822("uid-1", "acct@x.com", "INBOX", RAW).expect("parse");
+        assert_eq!(m.id, "uid-1");
+        assert_eq!(m.subject, "Closing date");
+        assert_eq!(m.from_address.as_deref(), Some("pat@hender.com"));
+        assert_eq!(m.to.len(), 1);
+        assert_eq!(m.internet_message_id.as_deref(), Some("abc@hender.com")); // <> stripped
+        assert_eq!(m.thread_id.as_deref(), Some("root@hender.com")); // first Reference
+        assert_eq!(m.provider, "imap");
+        assert_eq!(m.account, "acct@x.com");
+        assert_eq!(m.folders, vec!["INBOX".to_string()]);
+        assert!(m.body_text.contains("Confirming May 14."));
+    }
+
+    #[test]
+    fn no_references_uses_own_message_id_as_thread() {
+        let raw = b"Subject: Solo\r\nMessage-ID: <solo@x.com>\r\n\r\nhi\r\n";
+        let m = from_rfc822("uid-2", "a", "INBOX", raw).expect("parse");
+        assert_eq!(m.thread_id.as_deref(), Some("solo@x.com"));
+    }
+
+    #[test]
+    fn html_only_sets_html_body_type() {
+        let raw = b"Subject: HTML msg\r\nContent-Type: text/html\r\n\r\n<p>Hello</p>\r\n";
+        let m = from_rfc822("uid-3", "a", "INBOX", raw).expect("parse");
+        assert_eq!(m.body_content_type, BodyContentType::Html);
+        assert!(m.body_text.contains("<p>Hello</p>") || m.body_text.contains("Hello"));
+    }
+
+    #[test]
+    fn returns_none_for_empty_input() {
+        // An empty slice is not a valid RFC822 message — but mail-parser may
+        // still return Some (it is lenient). We only require that if it returns
+        // Some, it doesn't panic.
+        let _ = from_rfc822("uid-4", "a", "INBOX", b"");
+    }
+
+    #[test]
+    fn in_reply_to_used_when_no_references() {
+        let raw = b"Subject: Reply\r\nMessage-ID: <reply@x.com>\r\nIn-Reply-To: <parent@x.com>\r\n\r\nbody\r\n";
+        let m = from_rfc822("uid-5", "a", "INBOX", raw).expect("parse");
+        assert_eq!(m.thread_id.as_deref(), Some("parent@x.com"));
+    }
+
+    #[test]
+    fn conversation_id_is_none_and_folders_set() {
+        let m = from_rfc822("uid-6", "a", "Sent", RAW).expect("parse");
+        assert!(m.conversation_id.is_none());
+        assert_eq!(m.folders, vec!["Sent".to_string()]);
+    }
+}

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -1,5 +1,6 @@
 pub mod model;
 pub mod normalize;
+pub mod provider;
 pub mod store;
 pub mod graph;
 pub mod oauth;

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -22,6 +22,10 @@ const KEYCHAIN_REFRESH_KEY: &str = "ms-refresh-token";
 /// Account id for the single Microsoft 365 account (one refresh token today).
 /// Cursors are scoped by (provider, account, folder); see `sync_folder_provider`.
 const M365_ACCOUNT: &str = "default";
+
+const IMAP_KEYCHAIN_SERVICE: &str = "keepance-mail-imap";
+const IMAP_CONFIG_KEY: &str = "config"; // JSON {account,host,port,username}
+const IMAP_PASSWORD_KEY: &str = "password";
 pub const SYNC_PROGRESS_EVENT: &str = "mail-sync-progress";
 /// G5: per-message event that carries decrypted text to the renderer for
 /// MiniSearch indexing. The text lives only in renderer-process memory.
@@ -136,6 +140,26 @@ pub struct SyncProgress {
     pub removed: u32,
 }
 
+/// Stored IMAP account configuration (no password — stored separately).
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ImapConfig {
+    pub account: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+}
+
+/// Load the stored IMAP config + password from the keychain, if configured.
+fn load_imap_config() -> Option<(ImapConfig, String)> {
+    let cfg_e = keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_CONFIG_KEY).ok()?;
+    let cfg_json = cfg_e.get_password().ok()?;
+    let cfg: ImapConfig = serde_json::from_str(&cfg_json).ok()?;
+    let pw_e = keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_PASSWORD_KEY).ok()?;
+    let pw = pw_e.get_password().ok()?;
+    Some((cfg, pw))
+}
+
 #[tauri::command]
 pub async fn mail_set_workspace(
     state: State<'_, MailState>,
@@ -207,6 +231,54 @@ async fn fresh_access_token() -> Result<String, String> {
 #[tauri::command]
 pub async fn mail_cancel_sync(state: State<'_, MailState>) -> Result<(), String> {
     state.cancel.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Validate IMAP credentials by listing folders, then store them in the OS keychain.
+/// account id = the username (email). Never logs the password.
+#[tauri::command]
+pub async fn mail_imap_connect(
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+) -> Result<(), String> {
+    use crate::commands::mail::imap::ImapProvider;
+    let provider = ImapProvider {
+        host: host.clone(),
+        port,
+        username: username.clone(),
+        password: password.clone(),
+        account: username.clone(),
+    };
+    // Validate the connection (also rejects bad host/credentials up front).
+    provider.list_folders().await.map_err(|e| format!("Could not connect: {e}"))?;
+    let cfg = ImapConfig { account: username.clone(), host, port, username };
+    let cfg_json = serde_json::to_string(&cfg).map_err(|e| e.to_string())?;
+    keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_CONFIG_KEY)
+        .map_err(|e| e.to_string())?
+        .set_password(&cfg_json)
+        .map_err(|e| e.to_string())?;
+    keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_PASSWORD_KEY)
+        .map_err(|e| e.to_string())?
+        .set_password(&password)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mail_imap_is_connected() -> Result<bool, String> {
+    Ok(load_imap_config().is_some())
+}
+
+#[tauri::command]
+pub async fn mail_imap_disconnect() -> Result<(), String> {
+    if let Ok(e) = keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_CONFIG_KEY) {
+        let _ = e.delete_credential();
+    }
+    if let Ok(e) = keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_PASSWORD_KEY) {
+        let _ = e.delete_credential();
+    }
     Ok(())
 }
 
@@ -426,6 +498,106 @@ async fn mail_sync_all_inner(
         .await
         .map_err(|e| e.to_string())?;
     }
+
+    // ── IMAP account (if configured) — runs after M365 ────────────────────
+    if let Some((imap_cfg, imap_pw)) = load_imap_config() {
+        use crate::commands::mail::imap::ImapProvider;
+        let provider = ImapProvider {
+            host: imap_cfg.host.clone(),
+            port: imap_cfg.port,
+            username: imap_cfg.username.clone(),
+            password: imap_pw,
+            account: imap_cfg.account.clone(),
+        };
+        let folders = provider.list_folders().await.map_err(|e| e.to_string())?;
+        for folder in folders {
+            if cancel.load(Ordering::SeqCst) {
+                let _ = app.emit(
+                    SYNC_PROGRESS_EVENT,
+                    SyncProgress {
+                        status: "cancelled".into(),
+                        folder: None,
+                        written: 0,
+                        removed: 0,
+                    },
+                );
+                return Ok(());
+            }
+            let app2 = app.clone();
+            let fid2 = folder.id.clone();
+            let emit = move |w: u32, r: u32| {
+                let _ = app2.emit(
+                    SYNC_PROGRESS_EVENT,
+                    SyncProgress {
+                        status: "syncing".into(),
+                        folder: Some(fid2.clone()),
+                        written: w,
+                        removed: r,
+                    },
+                );
+            };
+            let workspace_for_index = workspace.clone();
+            let enc_key_for_index = enc_key;
+            let app3 = app.clone();
+            let index_callback = move |id: &str, text: &str| {
+                let path_key = format!("mail:{}", id);
+                let text_owned = text.to_string();
+                let ws = workspace_for_index.clone();
+                let key = enc_key_for_index;
+                // Fire-and-forget RAG indexing (G4).
+                let _ = tokio::task::spawn(async move {
+                    if let Err(e) = index_mail_text_internal(&ws, &path_key, &text_owned, &key).await {
+                        log::warn!("G4 mail index failed for {}: {}", path_key, e);
+                    }
+                });
+                // G5: pull the subject from the frontmatter (scoped to the fenced
+                // block, unquoted + unescaped) and emit the event for MiniSearch.
+                let subject = frontmatter_subject(text);
+                let _ = app3.emit(MAIL_INDEX_CHUNK_EVENT, MailIndexChunkPayload {
+                    doc_id: id.to_string(),
+                    subject,
+                    decrypted_text: text.to_string(),
+                });
+            };
+            // S3: tombstone_callback fires for each deleted message. It spawns a
+            // fire-and-forget async task to remove the LanceDB RAG chunks keyed
+            // "mail:<id>" so deleted email stops surfacing in rag_retrieve.
+            let workspace_for_tombstone = workspace.clone();
+            let tombstone_callback = move |id: &str| {
+                let path_key = format!("mail:{}", id);
+                let ws = workspace_for_tombstone.clone();
+                let _ = tokio::task::spawn(async move {
+                    // Reuse the same store::delete_path helper used by rag_delete_path.
+                    match crate::commands::rag::store::open_connection(&ws).await {
+                        Ok(conn) => {
+                            let names = conn.table_names().execute().await.unwrap_or_default();
+                            if names.iter().any(|n| n == crate::commands::rag::store::TABLE_NAME) {
+                                if let Ok(table) = conn
+                                    .open_table(crate::commands::rag::store::TABLE_NAME)
+                                    .execute()
+                                    .await
+                                {
+                                    if let Err(e) = crate::commands::rag::store::delete_path(&table, &path_key).await {
+                                        log::warn!("S3 tombstone: delete RAG chunks for {} failed: {}", path_key, e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!("S3 tombstone: open lancedb for {} failed: {}", path_key, e);
+                        }
+                    }
+                });
+            };
+            sync::sync_folder_provider(
+                &provider, &store, &workspace, &folder, &imap_cfg.account, &enc_key,
+                &emit, &index_callback, &tombstone_callback,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        }
+    }
+
     let _ = app.emit(
         SYNC_PROGRESS_EVENT,
         SyncProgress {

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -255,14 +255,18 @@ pub async fn mail_imap_connect(
     provider.list_folders().await.map_err(|e| format!("Could not connect: {e}"))?;
     let cfg = ImapConfig { account: username.clone(), host, port, username };
     let cfg_json = serde_json::to_string(&cfg).map_err(|e| e.to_string())?;
-    keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_CONFIG_KEY)
-        .map_err(|e| e.to_string())?
-        .set_password(&cfg_json)
-        .map_err(|e| e.to_string())?;
-    keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_PASSWORD_KEY)
-        .map_err(|e| e.to_string())?
-        .set_password(&password)
-        .map_err(|e| e.to_string())?;
+    let cfg_entry =
+        keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_CONFIG_KEY).map_err(|e| e.to_string())?;
+    cfg_entry.set_password(&cfg_json).map_err(|e| e.to_string())?;
+    let pw_entry =
+        keyring::Entry::new(IMAP_KEYCHAIN_SERVICE, IMAP_PASSWORD_KEY).map_err(|e| e.to_string())?;
+    if let Err(e) = pw_entry.set_password(&password) {
+        // Don't leave a config without its password: load_imap_config requires
+        // both, so a half-write would surface as a confusing "not connected"
+        // after an apparently-successful connect. Roll back the config entry.
+        let _ = cfg_entry.delete_credential();
+        return Err(e.to_string());
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -19,6 +19,9 @@ use crate::commands::mail::store::EncryptedMailStore;
 
 const KEYCHAIN_SERVICE: &str = "keepance-mail-ms";
 const KEYCHAIN_REFRESH_KEY: &str = "ms-refresh-token";
+/// Account id for the single Microsoft 365 account (one refresh token today).
+/// Cursors are scoped by (provider, account, folder); see `sync_folder_provider`.
+const M365_ACCOUNT: &str = "default";
 pub const SYNC_PROGRESS_EVENT: &str = "mail-sync-progress";
 /// G5: per-message event that carries decrypted text to the renderer for
 /// MiniSearch indexing. The text lives only in renderer-process memory.
@@ -417,7 +420,7 @@ async fn mail_sync_all_inner(
             });
         };
         sync::sync_folder_provider(
-            &provider, &store, &workspace, &folder, &enc_key, &emit,
+            &provider, &store, &workspace, &folder, M365_ACCOUNT, &enc_key, &emit,
             &index_callback, &tombstone_callback,
         )
         .await

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -7,6 +7,7 @@ pub mod oauth;
 pub mod sync;
 pub mod crypto;
 pub mod fde;
+pub mod imap;
 
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src-tauri/src/commands/mail/mod.rs
+++ b/src-tauri/src/commands/mail/mod.rs
@@ -12,8 +12,8 @@ use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
-use crate::commands::mail::graph::GraphClient;
 use crate::commands::mail::oauth::{OAuth, TokenOutcome};
+use crate::commands::mail::provider::MailProvider;
 use crate::commands::mail::store::EncryptedMailStore;
 
 const KEYCHAIN_SERVICE: &str = "keepance-mail-ms";
@@ -318,38 +318,17 @@ async fn mail_sync_all_inner(
     let enc_key = crate::commands::mail::crypto::get_or_create_master_key()
         .map_err(|e| e.to_string())?;
 
-    // FIX C: paginate folder enumeration — follow @odata.nextLink until exhausted.
-    let mut ids: Vec<String> = Vec::new();
-    {
+    // Enumerate folders through the provider seam (M365 GraphProvider for now;
+    // Gmail/IMAP providers slot in here unchanged).
+    let folders = {
         let token = fresh_access_token().await?;
-        let list_client = GraphClient::new(token);
-        let mut next_url = Some(format!(
-            "{}/v1.0/me/mailFolders?$top=200",
-            list_client.base()
-        ));
-        while let Some(url) = next_url {
-            let page = list_client
-                .get_json(&url)
-                .await
-                .map_err(|e| e.to_string())?;
-            if let Some(arr) = page.get("value").and_then(|v| v.as_array()) {
-                for f in arr {
-                    if let Some(id) = f.get("id").and_then(|s| s.as_str()) {
-                        ids.push(id.to_string());
-                    }
-                }
-            }
-            // Follow the next page if present.
-            next_url = page
-                .get("@odata.nextLink")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-        }
-    }
+        let provider = crate::commands::mail::graph::GraphProvider::new(token);
+        provider.list_folders().await.map_err(|e| e.to_string())?
+    };
 
     // FIX B: refresh the access token before each folder so long backfills
     // never outlive the 3600-second token lifetime.
-    for fid in ids {
+    for folder in folders {
         if cancel.load(Ordering::SeqCst) {
             let _ = app.emit(
                 SYNC_PROGRESS_EVENT,
@@ -363,9 +342,9 @@ async fn mail_sync_all_inner(
             return Ok(());
         }
         let token = fresh_access_token().await?;
-        let client = GraphClient::new(token);
+        let provider = crate::commands::mail::graph::GraphProvider::new(token);
         let app2 = app.clone();
-        let fid2 = fid.clone();
+        let fid2 = folder.id.clone();
         let emit = move |w: u32, r: u32| {
             let _ = app2.emit(
                 SYNC_PROGRESS_EVENT,
@@ -436,8 +415,8 @@ async fn mail_sync_all_inner(
                 }
             });
         };
-        sync::sync_folder_enc(
-            &client, &store, &workspace, &fid, &enc_key, &emit,
+        sync::sync_folder_provider(
+            &provider, &store, &workspace, &folder, &enc_key, &emit,
             &index_callback, &tombstone_callback,
         )
         .await

--- a/src-tauri/src/commands/mail/model.rs
+++ b/src-tauri/src/commands/mail/model.rs
@@ -29,6 +29,10 @@ pub struct MailMessage {
     pub from_address: Option<String>,
     pub to: Vec<Recipient>,
     pub cc: Vec<Recipient>,
+    pub folders: Vec<String>,
+    pub thread_id: Option<String>,
+    pub provider: String,
+    pub account: String,
     pub has_attachments: bool,
     pub body_content_type: BodyContentType,
     pub body_text: String,
@@ -76,12 +80,14 @@ impl MailMessage {
             Some("html") => BodyContentType::Html,
             _ => BodyContentType::Text,
         };
+        let conversation_id = v
+            .get("conversationId")
+            .and_then(|s| s.as_str())
+            .map(String::from);
         Some(MailMessage {
             id,
-            conversation_id: v
-                .get("conversationId")
-                .and_then(|s| s.as_str())
-                .map(String::from),
+            thread_id: conversation_id.clone(),
+            conversation_id,
             internet_message_id: v
                 .get("internetMessageId")
                 .and_then(|s| s.as_str())
@@ -105,6 +111,9 @@ impl MailMessage {
                 .map(String::from),
             to: recipients(v, "toRecipients"),
             cc: recipients(v, "ccRecipients"),
+            folders: vec![],
+            provider: "m365".to_string(),
+            account: String::new(),
             has_attachments: v
                 .get("hasAttachments")
                 .and_then(|b| b.as_bool())
@@ -167,5 +176,14 @@ mod tests {
         let m = MailMessage::from_graph(&j).unwrap();
         assert_eq!(m.body_content_type, BodyContentType::Html);
         assert_eq!(m.body_text, "<p>Hi <b>there</b></p>"); // raw kept; stripping is a later task
+    }
+
+    #[test]
+    fn from_graph_sets_provenance_fields() {
+        let m = MailMessage::from_graph(&sample_graph_json()).expect("parse");
+        assert_eq!(m.provider, "m365");
+        assert_eq!(m.thread_id.as_deref(), Some("conv-9"));   // from conversationId
+        assert!(m.folders.is_empty());                         // folder is assigned by the sync layer
+        assert_eq!(m.account, "");                             // account is assigned by the sync layer
     }
 }

--- a/src-tauri/src/commands/mail/normalize.rs
+++ b/src-tauri/src/commands/mail/normalize.rs
@@ -101,6 +101,15 @@ pub fn to_markdown(m: &MailMessage) -> String {
         s.push_str(&format!("internet_message_id: \"{}\"\n", yaml_escape(i)));
     }
     s.push_str(&format!("subject: \"{}\"\n", yaml_escape(&m.subject)));
+    if let Some(t) = &m.thread_id {
+        s.push_str(&format!("thread_id: \"{}\"\n", yaml_escape(t)));
+    }
+    if !m.folders.is_empty() {
+        s.push_str(&format!("folders: \"{}\"\n", yaml_escape(&m.folders.join(", "))));
+    }
+    if !m.provider.is_empty() {
+        s.push_str(&format!("provider: \"{}\"\n", yaml_escape(&m.provider)));
+    }
     s.push_str(&format!("from: \"{}\"\n", yaml_escape(&from)));
     s.push_str(&format!("to: \"{}\"\n", yaml_escape(&to)));
     if !cc.is_empty() {
@@ -138,6 +147,10 @@ mod tests {
                 address: Some("me@firm.com".into()),
             }],
             cc: vec![],
+            folders: vec![],
+            thread_id: None,
+            provider: "m365".into(),
+            account: String::new(),
             has_attachments: false,
             body_content_type: BodyContentType::Text,
             body_text: "Confirming May 14.".into(),
@@ -220,6 +233,18 @@ mod tests {
         // The only `---` fences are the opening and closing frontmatter fences.
         let fence_lines = md.lines().filter(|l| l.trim() == "---").count();
         assert_eq!(fence_lines, 2, "expected exactly 2 frontmatter fences, got:\n{md}");
+    }
+
+    #[test]
+    fn frontmatter_includes_thread_and_provider() {
+        let mut m = msg();
+        m.thread_id = Some("conv-9".into());
+        m.provider = "m365".into();
+        m.folders = vec!["Inbox".into(), "Important".into()];
+        let md = to_markdown(&m);
+        assert!(md.contains("thread_id: \"conv-9\""), "got:\n{md}");
+        assert!(md.contains("provider: \"m365\""), "got:\n{md}");
+        assert!(md.contains("folders: \"Inbox, Important\""), "got:\n{md}");
     }
 
     #[test]

--- a/src-tauri/src/commands/mail/provider.rs
+++ b/src-tauri/src/commands/mail/provider.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use crate::commands::mail::model::MailMessage;
+
+/// A provider folder/label (Outlook folder, Gmail label, IMAP mailbox).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoteFolder { pub id: String, pub display_name: String }
+
+/// Where a folder's sync resumes from. Opaque per provider (Graph delta link,
+/// Gmail historyId, or "UIDVALIDITY:lastUID").
+#[derive(Debug, Clone, PartialEq)]
+pub enum Cursor { Backfill, Resume(String) }
+impl Cursor {
+    pub fn from_token(t: Option<String>) -> Cursor {
+        match t { Some(s) => Cursor::Resume(s), None => Cursor::Backfill }
+    }
+    /// The token to persist for resuming, if any.
+    pub fn token(&self) -> Option<&str> {
+        match self { Cursor::Resume(s) => Some(s.as_str()), Cursor::Backfill => None }
+    }
+}
+
+/// One page of changes for a folder.
+pub struct ChangePage {
+    pub messages: Vec<MailMessage>,   // already normalized
+    pub removed_ids: Vec<String>,     // tombstones
+    /// Resume token for the next call; None means this folder round is complete.
+    pub next: Option<String>,
+    /// True when the round completed (the `next` token, if any, is a deltaLink/historyId to save).
+    pub done: bool,
+}
+
+/// A source of email for one account. Implemented per provider (M365, Gmail, IMAP).
+#[async_trait]
+pub trait MailProvider: Send + Sync {
+    /// Stable provider id: "m365" | "gmail" | "imap".
+    fn kind(&self) -> &'static str;
+    /// List the account's folders/labels/mailboxes.
+    async fn list_folders(&self) -> anyhow::Result<Vec<RemoteFolder>>;
+    /// Fetch one page of changes for `folder` starting from `cursor`.
+    async fn fetch_changes(&self, folder: &RemoteFolder, cursor: &Cursor)
+        -> anyhow::Result<ChangePage>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn cursor_from_token_maps_some_and_none() {
+        assert_eq!(Cursor::from_token(Some("abc".into())), Cursor::Resume("abc".into()));
+        assert_eq!(Cursor::from_token(None), Cursor::Backfill);
+    }
+}

--- a/src-tauri/src/commands/mail/sync.rs
+++ b/src-tauri/src/commands/mail/sync.rs
@@ -226,6 +226,7 @@ pub async fn sync_folder_provider<F, I, T>(
     store: &(dyn MailStore + Sync),
     workspace_root: &Path,
     folder: &RemoteFolder,
+    account: &str,
     key: &[u8; 32],
     emit: &F,
     index_callback: &I,
@@ -236,7 +237,11 @@ where
     I: Fn(&str, &str) + Send + Sync,
     T: Fn(&str) + Send + Sync,
 {
-    let mut cursor = Cursor::from_token(store.get_cursor(&folder.id)?);
+    // Scope the resume cursor by provider + account + folder so multiple accounts
+    // (even two of the same provider, or an IMAP "INBOX" vs an M365 inbox) never
+    // collide on a folder id.
+    let cursor_key = format!("{}\u{1}{}\u{1}{}", provider.kind(), account, folder.id);
+    let mut cursor = Cursor::from_token(store.get_cursor(&cursor_key)?);
     let mut total = PageStats::default();
     loop {
         let page = provider.fetch_changes(folder, &cursor).await?;
@@ -244,7 +249,7 @@ where
         total.written += s.written;
         total.removed += s.removed;
         emit(total.written, total.removed);
-        if let Some(tok) = &page.next { store.set_cursor(&folder.id, tok)?; }
+        if let Some(tok) = &page.next { store.set_cursor(&cursor_key, tok)?; }
         if page.done { break; }
         cursor = Cursor::from_token(page.next);
     }

--- a/src-tauri/src/commands/mail/sync.rs
+++ b/src-tauri/src/commands/mail/sync.rs
@@ -2,6 +2,7 @@ use crate::commands::mail::crypto::encrypt_with_key;
 use crate::commands::mail::graph::{page_continuation, Continuation, DeltaGone, GraphClient};
 use crate::commands::mail::model::MailMessage;
 use crate::commands::mail::normalize::to_markdown;
+use crate::commands::mail::provider::{Cursor, MailProvider, RemoteFolder};
 use crate::commands::mail::store::{MailRecord, MailStore};
 use std::path::Path;
 
@@ -277,6 +278,38 @@ where
             }
             Continuation::End => break,
         }
+    }
+    Ok(total)
+}
+
+/// Provider-agnostic encrypted folder sync. Loops a provider's `fetch_changes`,
+/// persisting the resume cursor after each page, applying via `apply_messages_enc`.
+pub async fn sync_folder_provider<F, I, T>(
+    provider: &dyn MailProvider,
+    store: &(dyn MailStore + Sync),
+    workspace_root: &Path,
+    folder: &RemoteFolder,
+    key: &[u8; 32],
+    emit: &F,
+    index_callback: &I,
+    tombstone_callback: &T,
+) -> anyhow::Result<PageStats>
+where
+    F: Fn(u32, u32) + Send,
+    I: Fn(&str, &str) + Send + Sync,
+    T: Fn(&str) + Send + Sync,
+{
+    let mut cursor = Cursor::from_token(store.get_cursor(&folder.id)?);
+    let mut total = PageStats::default();
+    loop {
+        let page = provider.fetch_changes(folder, &cursor).await?;
+        let s = apply_messages_enc(store, workspace_root, &folder.id, &page.messages, &page.removed_ids, key, index_callback, tombstone_callback)?;
+        total.written += s.written;
+        total.removed += s.removed;
+        emit(total.written, total.removed);
+        if let Some(tok) = &page.next { store.set_cursor(&folder.id, tok)?; }
+        if page.done { break; }
+        cursor = Cursor::from_token(page.next);
     }
     Ok(total)
 }

--- a/src-tauri/src/commands/mail/sync.rs
+++ b/src-tauri/src/commands/mail/sync.rs
@@ -52,6 +52,54 @@ pub fn apply_page(store: &dyn MailStore, workspace_root: &Path, folder_id: &str,
     Ok(stats)
 }
 
+/// Apply already-normalized changes to the encrypted store + index. Provider-
+/// agnostic core used by `apply_page_enc` (Graph) and future Gmail/IMAP paths.
+pub fn apply_messages_enc<F, T>(
+    store: &dyn MailStore,
+    workspace_root: &Path,
+    folder_id: &str,
+    messages: &[MailMessage],
+    removed_ids: &[String],
+    key: &[u8; 32],
+    index_callback: &F,
+    tombstone_callback: &T,
+) -> anyhow::Result<PageStats>
+where
+    F: Fn(&str, &str),
+    T: Fn(&str),
+{
+    let mut stats = PageStats::default();
+    for id in removed_ids {
+        if id.is_empty() { continue; }
+        if let Some(rel) = store.tombstone(id)? {
+            let _ = std::fs::remove_file(workspace_root.join(&rel));
+            tombstone_callback(id);
+            stats.removed += 1;
+        }
+    }
+    for msg in messages {
+        let markdown = to_markdown(msg);
+        let blob_dir = workspace_root.join(".keepance").join("mail").join("blobs");
+        std::fs::create_dir_all(&blob_dir)?;
+        let safe = safe_filename(&msg.id);
+        let blob_filename = format!("{}.enc", safe);
+        let blob_abs = blob_dir.join(&blob_filename);
+        let encrypted = encrypt_with_key(markdown.as_bytes(), key)?;
+        std::fs::write(&blob_abs, &encrypted)?;
+        let rel = format!(".keepance/mail/blobs/{}", blob_filename);
+        store.upsert(&MailRecord {
+            id: msg.id.clone(),
+            folder_id: folder_id.to_string(),
+            internet_message_id: msg.internet_message_id.clone(),
+            relative_path: rel,
+            received_date_time: msg.received_date_time.clone(),
+        })?;
+        index_callback(&msg.id, &markdown);
+        stats.written += 1;
+    }
+    Ok(stats)
+}
+
 /// Encrypted variant of apply_page.
 ///
 /// Differences from `apply_page`:
@@ -82,64 +130,19 @@ where
     F: Fn(&str, &str),
     T: Fn(&str),
 {
-    let mut stats = PageStats::default();
-    let items = page
-        .get("value")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-
+    let items = page.get("value").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    let mut messages: Vec<MailMessage> = Vec::new();
+    let mut removed_ids: Vec<String> = Vec::new();
     for item in &items {
         let id = item.get("id").and_then(|s| s.as_str()).unwrap_or("");
-        if id.is_empty() {
-            continue;
-        }
-
+        if id.is_empty() { continue; }
         if MailMessage::is_removed(item) {
-            if let Some(rel) = store.tombstone(id)? {
-                // Delete the encrypted blob (relative path points to .enc file).
-                let _ = std::fs::remove_file(workspace_root.join(&rel));
-                // S3: delete the RAG chunks for this mail id so deleted email
-                // stops surfacing in rag_retrieve. The callback is fire-and-forget
-                // (spawned as a tokio task by the caller).
-                tombstone_callback(id);
-                stats.removed += 1;
-            }
-            continue;
-        }
-
-        if let Some(msg) = MailMessage::from_graph(item) {
-            let markdown = to_markdown(&msg);
-
-            // Encrypt the markdown and write the blob.
-            let blob_dir = workspace_root
-                .join(".keepance")
-                .join("mail")
-                .join("blobs");
-            std::fs::create_dir_all(&blob_dir)?;
-            let safe = safe_filename(&msg.id);
-            let blob_filename = format!("{}.enc", safe);
-            let blob_abs = blob_dir.join(&blob_filename);
-            let encrypted = encrypt_with_key(markdown.as_bytes(), key)?;
-            std::fs::write(&blob_abs, &encrypted)?;
-
-            let rel = format!(".keepance/mail/blobs/{}", blob_filename);
-            store.upsert(&MailRecord {
-                id: msg.id.clone(),
-                folder_id: folder_id.to_string(),
-                internet_message_id: msg.internet_message_id.clone(),
-                relative_path: rel,
-                received_date_time: msg.received_date_time.clone(),
-            })?;
-
-            // Feed decrypted text to the in-memory indexer (RAG + keyword).
-            // This is the ONLY place the plaintext exists — never written to disk.
-            index_callback(&msg.id, &markdown);
-
-            stats.written += 1;
+            removed_ids.push(id.to_string());
+        } else if let Some(m) = MailMessage::from_graph(item) {
+            messages.push(m);
         }
     }
-    Ok(stats)
+    apply_messages_enc(store, workspace_root, folder_id, &messages, &removed_ids, key, index_callback, tombstone_callback)
 }
 
 /// G7: Migration — remove the plaintext `Mail/` directory written by Phase 1.
@@ -436,6 +439,25 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].0, "m3");
         assert!(pairs[0].1.contains("Index me!"), "callback receives plaintext");
+    }
+
+    #[test]
+    fn apply_messages_enc_writes_blob_and_indexes() {
+        let store = FakeStore::default();
+        let dir = tempfile::TempDir::new().unwrap();
+        let key = [0x11u8; 32];
+        let mut m = crate::commands::mail::model::MailMessage::from_graph(&serde_json::json!({
+            "id":"mm1","subject":"Hi","body":{"contentType":"text","content":"hello world"}
+        })).unwrap();
+        m.account = "acct".into();
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let cap2 = captured.clone();
+        let stats = apply_messages_enc(&store, dir.path(), "inbox", &[m], &[], &key,
+            &|id: &str, _t: &str| { cap2.lock().unwrap().push(id.to_string()); },
+            &|_id: &str| {}).unwrap();
+        assert_eq!(stats.written, 1);
+        assert!(store.contains("mm1").unwrap());
+        assert_eq!(captured.lock().unwrap().as_slice(), &["mm1"]);
     }
 
     // S3 tests ----------------------------------------------------------------

--- a/src-tauri/src/commands/mail/sync.rs
+++ b/src-tauri/src/commands/mail/sync.rs
@@ -219,69 +219,6 @@ pub async fn sync_folder<F: Fn(u32, u32) + Send>(
     Ok(total)
 }
 
-/// Encrypted variant of sync_folder. Uses apply_page_enc instead of apply_page.
-/// `index_callback` receives (doc_id, plaintext_markdown) for each new message —
-/// the caller feeds this to the RAG indexer and MiniSearch without persisting it.
-/// `tombstone_callback` receives (doc_id) for each tombstoned message — the
-/// caller spawns an async task to delete the corresponding LanceDB RAG chunks (S3).
-pub async fn sync_folder_enc<F, I, T>(
-    client: &GraphClient,
-    store: &(dyn MailStore + Sync),
-    workspace_root: &Path,
-    folder_id: &str,
-    key: &[u8; 32],
-    emit: &F,
-    index_callback: &I,
-    tombstone_callback: &T,
-) -> anyhow::Result<PageStats>
-where
-    F: Fn(u32, u32) + Send,
-    I: Fn(&str, &str) + Send + Sync,
-    T: Fn(&str) + Send + Sync,
-{
-    let mut url = match store.get_cursor(folder_id)? {
-        Some(saved) => saved,
-        None => client.delta_start_url(folder_id),
-    };
-    let mut total = PageStats::default();
-    let mut delta_gone_count = 0u32;
-    loop {
-        let page = match client.get_json(&url).await {
-            Ok(p) => p,
-            Err(e) if e.downcast_ref::<DeltaGone>().is_some() => {
-                // Bound the 410 resync loop: a server stuck on 410 must not spin
-                // forever (it holds the sync slot and blocks cancellation).
-                delta_gone_count += 1;
-                if delta_gone_count > MAX_DELTA_RESETS {
-                    return Err(anyhow::anyhow!(
-                        "folder {folder_id}: delta token expired {delta_gone_count}x in a row; giving up"
-                    ));
-                }
-                store.set_cursor(folder_id, &client.delta_start_url(folder_id))?;
-                url = client.delta_start_url(folder_id);
-                continue;
-            }
-            Err(e) => return Err(e),
-        };
-        let s = apply_page_enc(store, workspace_root, folder_id, &page, key, index_callback, tombstone_callback)?;
-        total.written += s.written;
-        total.removed += s.removed;
-        emit(total.written, total.removed);
-        match page_continuation(&page) {
-            Continuation::Next(next) => {
-                store.set_cursor(folder_id, &next)?;
-                url = next;
-            }
-            Continuation::Delta(delta) => {
-                store.set_cursor(folder_id, &delta)?;
-                break;
-            }
-            Continuation::End => break,
-        }
-    }
-    Ok(total)
-}
-
 /// Provider-agnostic encrypted folder sync. Loops a provider's `fetch_changes`,
 /// persisting the resume cursor after each page, applying via `apply_messages_enc`.
 pub async fn sync_folder_provider<F, I, T>(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,10 @@ pub fn run() {
             commands::mail::mail_cancel_sync,
             // G6 — OS full-disk encryption detection + nudge in MailConnect.
             commands::mail::fde::mail_fde_status,
+            // IMAP multi-provider support.
+            commands::mail::mail_imap_connect,
+            commands::mail::mail_imap_is_connected,
+            commands::mail::mail_imap_disconnect,
         ])
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/src/components/settings/MailImapConnect.tsx
+++ b/src/components/settings/MailImapConnect.tsx
@@ -113,7 +113,7 @@ export function MailImapConnect() {
             <input
               id="imap-password"
               type="password"
-              placeholder="App password or account password"
+              placeholder="App password (Gmail and Outlook require one)"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/src/components/settings/MailImapConnect.tsx
+++ b/src/components/settings/MailImapConnect.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { mailImapConnect, mailImapIsConnected, mailImapDisconnect } from '@/utils/mail-commands';
+
+export function MailImapConnect() {
+  const [connected, setConnected] = useState(false);
+  const [host, setHost] = useState('');
+  const [port, setPort] = useState(993);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  useEffect(() => {
+    mailImapIsConnected().then(setConnected).catch(() => {});
+  }, []);
+
+  async function connect() {
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      await mailImapConnect({ host, port, username, password });
+      setConnected(true);
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : 'Could not connect. Check your settings and try again.');
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function disconnect() {
+    try {
+      await mailImapDisconnect();
+    } catch {
+      // Best-effort disconnect; clear local state regardless.
+    }
+    setConnected(false);
+  }
+
+  return (
+    <section className="mt-4 rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="text-sm font-semibold text-slate-900">Other email (IMAP)</h3>
+      <p className="mt-1 text-sm text-slate-600">
+        Works with Gmail (via a{' '}
+        <a
+          href="https://myaccount.google.com/apppasswords"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          Google app password
+        </a>
+        ), Fastmail, Outlook IMAP, or any standard IMAP host. Your password is stored only in
+        this device's keychain and never leaves your machine.
+      </p>
+
+      {!connected && (
+        <form
+          className="mt-3 space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void connect();
+          }}
+        >
+          <div className="grid grid-cols-[1fr_auto] gap-3">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="imap-host" className="text-xs font-medium text-slate-700">
+                Host
+              </label>
+              <input
+                id="imap-host"
+                type="text"
+                placeholder="imap.gmail.com"
+                value={host}
+                onChange={(e) => setHost(e.target.value)}
+                required
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-400"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="imap-port" className="text-xs font-medium text-slate-700">
+                Port
+              </label>
+              <input
+                id="imap-port"
+                type="number"
+                min={1}
+                max={65535}
+                value={port}
+                onChange={(e) => setPort(Number(e.target.value))}
+                required
+                className="w-20 rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-400"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="imap-username" className="text-xs font-medium text-slate-700">
+              Email / username
+            </label>
+            <input
+              id="imap-username"
+              type="text"
+              placeholder="you@example.com"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-400"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="imap-password" className="text-xs font-medium text-slate-700">
+              App password
+            </label>
+            <input
+              id="imap-password"
+              type="password"
+              placeholder="App password or account password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-400"
+            />
+          </div>
+
+          {connectError && (
+            <div className="rounded-md bg-slate-50 p-3 text-sm text-slate-800">
+              <p className="text-red-700 font-medium">Something went wrong: {connectError}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={connecting}
+            className="rounded-md bg-[#0A2540] px-3 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-60"
+          >
+            {connecting ? 'Connecting…' : 'Connect'}
+          </button>
+        </form>
+      )}
+
+      {connected && (
+        <div className="mt-3 text-sm text-slate-700">
+          <p className="font-medium text-green-700">Connected.</p>
+          <button
+            type="button"
+            onClick={() => void disconnect()}
+            className="mt-2 rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Disconnect
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -49,6 +49,7 @@ import { McpSettingsSection } from '@/components/settings/McpSettingsSection';
 import { OllamaSettingsSection } from '@/components/settings/OllamaSettingsSection';
 import { VoiceSettingsSection } from '@/components/settings/VoiceSettingsSection';
 import { MailConnect } from '@/components/settings/MailConnect';
+import { MailImapConnect } from '@/components/settings/MailImapConnect';
 import { LanguagePicker } from '@/components/settings/LanguagePicker';
 import { ApiKeyWizard } from '@/components/onboarding/ApiKeyWizard';
 import type { AuditEntry } from '@/types/audit';
@@ -746,6 +747,7 @@ export function SettingsModal({ open, onOpenChange, onAction, auditEntries, temp
             ) : activeCategory === 'integrations' ? (
               <>
                 <MailConnect />
+                <MailImapConnect />
                 <McpSettingsSection />
                 <OllamaSettingsSection />
               </>

--- a/src/utils/mail-commands.ts
+++ b/src/utils/mail-commands.ts
@@ -52,3 +52,18 @@ export async function mailFdeStatus(): Promise<FdeStatus> {
   if (!isTauri()) return { status: 'unknown', platform: 'browser' };
   return invoke<FdeStatus>('mail_fde_status');
 }
+
+// IMAP multi-provider support
+export interface ImapConnectInput { host: string; port: number; username: string; password: string; }
+export async function mailImapConnect(input: ImapConnectInput): Promise<void> {
+  if (!isTauri()) throw new Error('Email connect is only available in the desktop app.');
+  return invoke<void>('mail_imap_connect', { host: input.host, port: input.port, username: input.username, password: input.password });
+}
+export async function mailImapIsConnected(): Promise<boolean> {
+  if (!isTauri()) return false;
+  return invoke<boolean>('mail_imap_is_connected');
+}
+export async function mailImapDisconnect(): Promise<void> {
+  if (!isTauri()) return;
+  return invoke<void>('mail_imap_disconnect');
+}

--- a/tests/unit/settings/MailImapConnect.test.tsx
+++ b/tests/unit/settings/MailImapConnect.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockMailImapConnect = vi.fn();
+const mockMailImapIsConnected = vi.fn();
+const mockMailImapDisconnect = vi.fn();
+
+vi.mock('@/utils/mail-commands', () => ({
+  get mailImapConnect() { return mockMailImapConnect; },
+  get mailImapIsConnected() { return mockMailImapIsConnected; },
+  get mailImapDisconnect() { return mockMailImapDisconnect; },
+}));
+
+import { MailImapConnect } from '@/components/settings/MailImapConnect';
+
+describe('MailImapConnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMailImapIsConnected.mockResolvedValue(false);
+    mockMailImapConnect.mockResolvedValue(undefined);
+    mockMailImapDisconnect.mockResolvedValue(undefined);
+  });
+
+  it('renders the connect form when not connected', async () => {
+    render(<MailImapConnect />);
+    // Wait for the mount effect to resolve so the not-connected form is shown.
+    await waitFor(() => expect(mockMailImapIsConnected).toHaveBeenCalled());
+    expect(screen.getByLabelText(/host/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/port/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email \/ username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/app password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^connect$/i })).toBeInTheDocument();
+  });
+
+  it('calls mailImapConnect with the right args and transitions to Connected', async () => {
+    render(<MailImapConnect />);
+    await waitFor(() => expect(mockMailImapIsConnected).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/host/i), { target: { value: 'imap.gmail.com' } });
+    fireEvent.change(screen.getByLabelText(/port/i), { target: { value: '993' } });
+    fireEvent.change(screen.getByLabelText(/email \/ username/i), { target: { value: 'user@gmail.com' } });
+    fireEvent.change(screen.getByLabelText(/app password/i), { target: { value: 'secret123' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+    await waitFor(() =>
+      expect(mockMailImapConnect).toHaveBeenCalledWith({
+        host: 'imap.gmail.com',
+        port: 993,
+        username: 'user@gmail.com',
+        password: 'secret123',
+      })
+    );
+    expect(await screen.findByText(/connected\./i)).toBeInTheDocument();
+  });
+
+  it('shows error when mailImapConnect rejects (no unhandled rejection)', async () => {
+    mockMailImapConnect.mockRejectedValue(new Error('auth failed'));
+
+    render(<MailImapConnect />);
+    await waitFor(() => expect(mockMailImapIsConnected).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/host/i), { target: { value: 'imap.fastmail.com' } });
+    fireEvent.change(screen.getByLabelText(/email \/ username/i), { target: { value: 'user@fastmail.com' } });
+    fireEvent.change(screen.getByLabelText(/app password/i), { target: { value: 'wrong' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/auth failed/i)).toBeInTheDocument();
+    // Form should still be visible (not transitioned to connected)
+    expect(screen.queryByText(/connected\./i)).not.toBeInTheDocument();
+  });
+
+  it('shows Connected immediately when mailImapIsConnected resolves true on mount', async () => {
+    mockMailImapIsConnected.mockResolvedValue(true);
+
+    render(<MailImapConnect />);
+
+    expect(await screen.findByText(/connected\./i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^connect$/i })).not.toBeInTheDocument();
+  });
+
+  it('calls mailImapDisconnect and returns to connect form when Disconnect is clicked', async () => {
+    mockMailImapIsConnected.mockResolvedValue(true);
+
+    render(<MailImapConnect />);
+    expect(await screen.findByText(/connected\./i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+
+    await waitFor(() => expect(mockMailImapDisconnect).toHaveBeenCalled());
+    expect(await screen.findByRole('button', { name: /^connect$/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Extends the (merged) Microsoft 365 email feature to be **multi-provider** behind one seam, and adds a full **IMAP** provider. Builds in sequence per the plan at `docs/superpowers/plans/2026-06-07-email-gmail-imap-multiprovider.md`.

### Phase 0 — provider seam (refactor, no behavior change)
- New `MailProvider` trait + `RemoteFolder`/`Cursor`/`ChangePage` (`provider.rs`).
- `MailMessage` gains provenance (folders/thread_id/provider/account).
- `apply_messages_enc` (provider-agnostic encrypted write path); `sync_folder_provider` (generic loop).
- M365 refactored onto the seam via `GraphProvider`; `mail_sync_all` rewired; dead `sync_folder_enc` removed. **M365 behavior unchanged** (regression-gated).

### IMAP provider (end-to-end)
- `async-imap` 0.11 + `tokio-native-tls` client: imaps (993), LOGIN, LIST, SELECT, UID FETCH `BODY.PEEK[]`. TLS cert validation on; never sets `\Seen`.
- `mail-parser` 0.11 RFC822 -> normalized `MailMessage` (threading via References/In-Reply-To).
- `ImapProvider`: UID/UIDVALIDITY incremental sync with bounded, unit-tested paging (`compute_batch_range`).
- Account-scoped cursors so multiple accounts never collide on a folder id.
- `mail_imap_connect/is_connected/disconnect` commands; credentials only in the OS keychain (validated on connect).
- IMAP sync runs alongside M365 in `mail_sync_all` (additive; M365 closures unchanged).
- `MailImapConnect.tsx` connect UI (Settings -> Integrations), light theme.

### Reach
Works with **Gmail (via a Google app-password)**, Fastmail, Outlook IMAP, or any IMAP host. Encryption-at-rest + RAG/keyword index are reused unchanged.

### Gmail native API
Deferred/optional: `gmail.readonly` is a Google restricted scope (CASA Tier 3, costly annual audit), and IMAP+app-password already covers Gmail. Plan keeps the Gmail-API path open in Google "Testing" mode if pursued.

### Tests / gates
- Rust: 201 lib tests pass (incl. new IMAP normalize + cursor/batch). All test targets compile (incl. `#[ignore]`d live E2E).
- Frontend: `tsc -b` 0 errors; `npm test` 2061 pass.
- Live IMAP fetch is manual/`#[ignore]`d (no server in CI); pure helpers are unit-tested.

### Follow-ups (tracked)
IMAP hard-delete (tombstone) detection via UID-diff; connect/command timeouts in the IMAP client; DRY the duplicated per-folder sync closures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)