### PR TITLE
chore: orphan cleanup (F2.7a) — wire URL dialog, validate URLs, canonical local-AI doc

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,35 @@ Layer sizes (≈): app 33 · features 279 · platform 179 · ui 34 · lib 4.
   platform/ui/lib, and wire it into the shell in `src/app/`. If two features need
   the same thing, it belongs in `platform/`, not copied or cross-imported.
 
+## Two local-AI paths — which is canonical
+
+Two on-device inference engines coexist and are **not duplicates** — one is the
+product's default, the other is an optional alternative for users who already
+run their own local models:
+
+- **Bundled "Local AI" (llama.cpp) — canonical for Local-only mode.** A
+  sidecar process Keepance downloads and manages itself
+  (`src-tauri/src/sidecars/llama_server.rs`, commands in
+  `src-tauri/src/commands/local_llm/`), fronted by
+  `src/platform/providers/AppLocalProvider.ts` (`providerId: 'keepance-local'`).
+  This is what "Download Local AI" in Settings → AI
+  (`src/features/settings/LocalAiSettingsControl.tsx`) sets up, and it's tried
+  first whenever a surface needs on-device generation.
+- **Ollama connector — optional BYO alternative.** A thin HTTP client
+  (`src/platform/providers/OllamaProvider.ts`) against a daemon the *user*
+  installs and runs (`http://127.0.0.1:11434`), no bundled binary. Configured
+  separately in the Account window
+  (`src/features/account/AccountWindow.tsx` → `OllamaSettingsSection.tsx`), not
+  in Settings → AI.
+- **The single resolution rule** lives in
+  `src/platform/providers/resolveLocalProvider.ts`: prefer the embedded engine
+  when its model is downloaded and ready, else fall back to the user's Ollama
+  daemon. Both satisfy "nothing leaves the device" equally — this only changes
+  *which* local engine runs, never whether Local-only mode's no-egress
+  guarantee holds. Don't duplicate this fallback logic elsewhere; route new
+  local-inference call sites through `resolveLocalGenerationProvider()` /
+  `resolveAvailableLocalGenerationProvider()`.
+
 ## History
 
 This structure landed in the 3.0 **feature-first reorganization** (2026-06): the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1097,7 +1097,7 @@ function App() {
 
 
   // Command-palette commands. See src/app/commands/useAppCommands.ts.
-  const commands = useAppCommands({ openTabs, activeTabPath, handleSaveFile, closeTab, toggleOutline, isSplit, splitPane, closeSplit, handleOpenBrowserTab, handleCreateDefaultDocument, sidebarActiveTab, setSidebarCollapsed, setShowWorkspaceSelector, setSidebarActiveTab, openAIAssistantTab, setShowSettingsModal, prompt });
+  const commands = useAppCommands({ openTabs, activeTabPath, handleSaveFile, closeTab, toggleOutline, isSplit, splitPane, closeSplit, handleOpenBrowserTab, handleCreateDefaultDocument, sidebarActiveTab, setSidebarCollapsed, setShowWorkspaceSelector, openAIAssistantTab, setShowSettingsModal, prompt });
 
   // Global keyboard shortcuts. See src/app/commands/useKeyboardShortcuts.ts.
   useKeyboardShortcuts({

--- a/src/app/commands/useAppCommands.ts
+++ b/src/app/commands/useAppCommands.ts
@@ -7,6 +7,26 @@ import { useEditorStore } from '@/platform/state/editorStore';
 
 type OpenTab = ReturnType<typeof useEditorStore.getState>['openTabs'][number];
 
+/**
+ * Adds a `https://` scheme to bare-domain input (e.g. "example.com") so
+ * `new URL()` downstream doesn't throw on otherwise-reasonable input.
+ */
+export function normalizeBrowserUrl(value: string): string {
+  const trimmed = value.trim();
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+/** Returns an error message for the prompt dialog, or undefined if valid. */
+export function validateBrowserUrl(value: string): string | undefined {
+  if (!value.trim()) return 'Enter a URL.';
+  try {
+    new URL(normalizeBrowserUrl(value));
+    return undefined;
+  } catch {
+    return 'Enter a valid URL, e.g. https://example.com.';
+  }
+}
+
 export interface AppCommandDeps {
   openTabs: OpenTab[];
   activeTabPath: string | null;
@@ -21,7 +41,6 @@ export interface AppCommandDeps {
   sidebarActiveTab: AppSurface;
   setSidebarCollapsed: (updater: (v: boolean) => boolean) => void;
   setShowWorkspaceSelector: (v: boolean) => void;
-  setSidebarActiveTab: (tab: AppSurface) => void;
   /** Opens the AI Assistant as a main-panel tab. The reimagined 3.0 sidebar has
    *  no 'ai-assistant' surface, so the old setSidebarActiveTab('ai-assistant')
    *  was a no-op (it set a sidebar tab that does not exist). */
@@ -153,13 +172,14 @@ export function useAppCommands(deps: AppCommandDeps): PaletteCommand[] {
           const url = await prompt('Enter URL:', '', {
             title: 'Open Browser Tab',
             placeholder: 'https://example.com',
+            validate: validateBrowserUrl,
           });
           if (url) {
-            handleOpenBrowserTab(url);
+            handleOpenBrowserTab(normalizeBrowserUrl(url));
           }
         },
       },
     ];
     return [...appCommands, ...baseCommands];
-  }, [openTabs, activeTabPath, handleSaveFile, closeTab, toggleOutline, isSplit, splitPane, closeSplit, handleOpenBrowserTab, handleCreateDefaultDocument, sidebarActiveTab, openAIAssistantTab]);
+  }, [openTabs, activeTabPath, handleSaveFile, closeTab, toggleOutline, isSplit, splitPane, closeSplit, handleOpenBrowserTab, handleCreateDefaultDocument, sidebarActiveTab, setSidebarCollapsed, setShowWorkspaceSelector, openAIAssistantTab, setShowSettingsModal, prompt]);
 }

--- a/src/app/lifecycle/useTabOpening.ts
+++ b/src/app/lifecycle/useTabOpening.ts
@@ -31,7 +31,16 @@ export function useTabOpening({
     (url: string, title?: string) => {
       // Generate a unique path for the browser tab
       const tabPath = `__browser__${Date.now()}`;
-      const tabName = title || new URL(url).hostname;
+      // Callers are expected to pass an already-validated absolute URL (see
+      // useAppCommands.ts's "Open Browser Tab" command), but hostname
+      // extraction stays defensive so a malformed url never throws here.
+      const tabName = title || (() => {
+        try {
+          return new URL(url).hostname;
+        } catch {
+          return url;
+        }
+      })();
 
       openTab(tabPath, tabName, '', 'browser', { url });
     },
@@ -54,7 +63,7 @@ export function useTabOpening({
     }
     const tabPath = `__ai_assistant__${Date.now()}`;
     openTab(tabPath, 'AI Assistant', '', 'ai-assistant');
-  }, [openTab]);
+  }, [openTab, setDocumentsView, setSidebarActiveTab]);
 
   // WS-B/C — open the read-only email viewer when an email citation is clicked
   // in chat. AIChatViewer dispatches `lantern:open-email` for `mail:<id>`
@@ -79,7 +88,7 @@ export function useTabOpening({
         setSidebarActiveTab('files');
         openTab(id, label, content, type, meta);
       },
-      [openTab],
+      [openTab, setDocumentsView, setSidebarActiveTab],
     ),
   );
 

--- a/src/features/documents/editor/FormattingToolbar.tsx
+++ b/src/features/documents/editor/FormattingToolbar.tsx
@@ -111,6 +111,8 @@ const primaryToolbarButtons: ToolbarButton[] = [
   {
     icon: Link,
     label: 'Link',
+    // handleClick special-cases 'Link' to prompt for a URL via insertLinkInEditMode;
+    // this action never runs but satisfies the required ToolbarButton.action field.
     action: (editor) => { editor.wrapSelection('[', '](url)'); },
   },
 ];
@@ -183,11 +185,25 @@ export function FormattingToolbar({ editorRef, className, isPreviewMode, onToggl
     return () => { window.removeEventListener('keydown', handleKeyDown); };
   }, [onTogglePreview]);
 
-  const handleClick = (action: (editor: MarkdownEditorRef) => void, previewAction?: () => void) => {
+  // Edit-mode Link: use the same in-app URL dialog as the preview-mode
+  // (createLink) path instead of inserting a literal "](url)" placeholder.
+  const insertLinkInEditMode = (editor: MarkdownEditorRef) => {
+    void (async () => {
+      const url = await prompt('Enter URL:', undefined, { title: 'Insert link', placeholder: 'https://…', confirmLabel: 'Insert' });
+      if (!url) return;
+      editor.wrapSelection('[', `](${url})`);
+    })();
+  };
+
+  const handleClick = (button: ToolbarButton, previewAction?: () => void) => {
     if (isPreviewMode && previewAction) {
       previewAction();
     } else if (editorRef.current) {
-      action(editorRef.current);
+      if (button.label === 'Link') {
+        insertLinkInEditMode(editorRef.current);
+      } else {
+        button.action(editorRef.current);
+      }
     }
   };
 
@@ -417,7 +433,7 @@ export function FormattingToolbar({ editorRef, className, isPreviewMode, onToggl
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0"
-            onClick={() => { handleClick(button.action, previewAction); }}
+            onClick={() => { handleClick(button, previewAction); }}
             title={button.shortcut ? `${button.label} (${button.shortcut})` : button.label}
             disabled={isPreviewMode}
           >
@@ -451,7 +467,7 @@ export function FormattingToolbar({ editorRef, className, isPreviewMode, onToggl
                   <DropdownMenuItem
                     key={button.label}
                     data-testid={`formatting-more-${button.label.toLowerCase().replace(/\s+/g, '-')}`}
-                    onClick={() => { handleClick(button.action, previewAction); }}
+                    onClick={() => { handleClick(button, previewAction); }}
                     className="gap-2"
                   >
                     <Icon className="h-4 w-4 shrink-0" />

--- a/tests/unit/app/useAppCommands-browser-url.test.tsx
+++ b/tests/unit/app/useAppCommands-browser-url.test.tsx
@@ -32,7 +32,6 @@ function baseDeps(overrides: Partial<AppCommandDeps> = {}): AppCommandDeps {
     sidebarActiveTab: 'files',
     setSidebarCollapsed: vi.fn(),
     setShowWorkspaceSelector: vi.fn(),
-    setSidebarActiveTab: vi.fn(),
     openAIAssistantTab: vi.fn(),
     setShowSettingsModal: vi.fn(),
     prompt: vi.fn(async () => null),

--- a/tests/unit/app/useAppCommands-browser-url.test.tsx
+++ b/tests/unit/app/useAppCommands-browser-url.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * F2.7a — "Open Browser Tab" URL hardening.
+ *
+ * Before this fix, the prompted URL went straight to handleOpenBrowserTab,
+ * which called `new URL(url).hostname` unguarded (see useTabOpening.ts).
+ * Typing a bare domain like "example.com" (no scheme) threw an uncaught
+ * TypeError. These tests lock in: (1) the pure validate/normalize helpers,
+ * and (2) that the command wires them into the prompt + the call to
+ * handleOpenBrowserTab.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  useAppCommands,
+  normalizeBrowserUrl,
+  validateBrowserUrl,
+  type AppCommandDeps,
+} from '@/app/commands/useAppCommands';
+
+function baseDeps(overrides: Partial<AppCommandDeps> = {}): AppCommandDeps {
+  return {
+    openTabs: [],
+    activeTabPath: null,
+    handleSaveFile: vi.fn(async () => {}),
+    closeTab: vi.fn(),
+    toggleOutline: vi.fn(),
+    isSplit: false,
+    splitPane: vi.fn(),
+    closeSplit: vi.fn(),
+    handleOpenBrowserTab: vi.fn(),
+    handleCreateDefaultDocument: vi.fn(async () => {}),
+    sidebarActiveTab: 'files',
+    setSidebarCollapsed: vi.fn(),
+    setShowWorkspaceSelector: vi.fn(),
+    setSidebarActiveTab: vi.fn(),
+    openAIAssistantTab: vi.fn(),
+    setShowSettingsModal: vi.fn(),
+    prompt: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+describe('validateBrowserUrl', () => {
+  it('rejects an empty/whitespace value', () => {
+    expect(validateBrowserUrl('')).toBe('Enter a URL.');
+    expect(validateBrowserUrl('   ')).toBe('Enter a URL.');
+  });
+
+  it('rejects unparseable input', () => {
+    expect(validateBrowserUrl('not a url')).toBe('Enter a valid URL, e.g. https://example.com.');
+  });
+
+  it('accepts a bare domain (normalized before parsing)', () => {
+    expect(validateBrowserUrl('example.com')).toBeUndefined();
+  });
+
+  it('accepts an absolute URL with an explicit scheme', () => {
+    expect(validateBrowserUrl('https://example.com/path')).toBeUndefined();
+  });
+});
+
+describe('normalizeBrowserUrl', () => {
+  it('adds https:// to a bare domain', () => {
+    expect(normalizeBrowserUrl('example.com')).toBe('https://example.com');
+  });
+
+  it('leaves an existing scheme untouched', () => {
+    expect(normalizeBrowserUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeBrowserUrl('  example.com  ')).toBe('https://example.com');
+  });
+});
+
+describe('useAppCommands — "Open Browser Tab" command', () => {
+  function getBrowserOpenCommand(deps: AppCommandDeps) {
+    const { result } = renderHook(() => useAppCommands(deps));
+    const command = result.current.find((c) => c.id === 'browser.open');
+    if (!command) throw new Error('browser.open command not found');
+    return command;
+  }
+
+  it('passes validateBrowserUrl to the prompt dialog', async () => {
+    const prompt = vi.fn(async () => null);
+    const command = getBrowserOpenCommand(baseDeps({ prompt }));
+
+    await command.action();
+
+    expect(prompt).toHaveBeenCalledWith(
+      'Enter URL:',
+      '',
+      expect.objectContaining({ validate: validateBrowserUrl })
+    );
+  });
+
+  it('normalizes a bare-domain URL before opening the tab', async () => {
+    const handleOpenBrowserTab = vi.fn();
+    const prompt = vi.fn(async () => 'example.com');
+    const command = getBrowserOpenCommand(baseDeps({ prompt, handleOpenBrowserTab }));
+
+    await command.action();
+
+    expect(handleOpenBrowserTab).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('does nothing when the prompt is cancelled', async () => {
+    const handleOpenBrowserTab = vi.fn();
+    const prompt = vi.fn(async () => null);
+    const command = getBrowserOpenCommand(baseDeps({ prompt, handleOpenBrowserTab }));
+
+    await command.action();
+
+    expect(handleOpenBrowserTab).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lifecycle/useTabOpening-browser-url.test.tsx
+++ b/tests/unit/lifecycle/useTabOpening-browser-url.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * F2.7a — handleOpenBrowserTab must never throw on a malformed URL.
+ *
+ * The normal path (useAppCommands.ts's "Open Browser Tab" command) always
+ * normalizes/validates before calling this, but the hostname lookup here
+ * stays defensive in case of a future caller that skips that step.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTabOpening } from '@/app/lifecycle/useTabOpening';
+
+function renderTabOpening(openTab = vi.fn()) {
+  const utils = renderHook(() =>
+    useTabOpening({
+      openTab,
+      setSidebarActiveTab: vi.fn(),
+      setDocumentsView: vi.fn(),
+    })
+  );
+  return { ...utils, openTab };
+}
+
+describe('useTabOpening — handleOpenBrowserTab', () => {
+  it('derives the tab title from a valid absolute URL', () => {
+    const { result, openTab } = renderTabOpening();
+
+    act(() => {
+      result.current.handleOpenBrowserTab('https://example.com/path');
+    });
+
+    expect(openTab).toHaveBeenCalledTimes(1);
+    const [, tabName, , type, metadata] = openTab.mock.calls[0];
+    expect(tabName).toBe('example.com');
+    expect(type).toBe('browser');
+    expect(metadata).toEqual({ url: 'https://example.com/path' });
+  });
+
+  it('falls back to the raw string instead of throwing on a malformed URL', () => {
+    const { result, openTab } = renderTabOpening();
+
+    expect(() => {
+      act(() => {
+        result.current.handleOpenBrowserTab('not a url');
+      });
+    }).not.toThrow();
+
+    expect(openTab).toHaveBeenCalledTimes(1);
+    const [, tabName] = openTab.mock.calls[0];
+    expect(tabName).toBe('not a url');
+  });
+
+  it('prefers an explicit title over the derived hostname', () => {
+    const { result, openTab } = renderTabOpening();
+
+    act(() => {
+      result.current.handleOpenBrowserTab('https://example.com', 'My Tab');
+    });
+
+    const [, tabName] = openTab.mock.calls[0];
+    expect(tabName).toBe('My Tab');
+  });
+});


### PR DESCRIPTION
F2.7a from the fix plan: the built-but-unreachable URL dialog is now wired to the insert-link button (closes R17 A.4); browser-tab URL input validated with clear errors (13 new tests); ARCHITECTURE.md documents the canonical local-AI path (bundled engine = Local-only mode; Ollama = optional BYO alternative). BrowserPanel placement flagged as misplaced (report-only). Gate green (5058 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)